### PR TITLE
🐛 모바일 브라우저에서 로고 이미지 로드 실패 수정

### DIFF
--- a/frontend/src/lib/components/layout/Footer.svelte
+++ b/frontend/src/lib/components/layout/Footer.svelte
@@ -4,7 +4,7 @@
 		<div class="h-[67px] w-[350px] flex items-center">
 			<img
 				src="/images/logo.png"
-				srcset="/images/logo@2x.png 2x, /images/logo@3x.png 3x"
+				srcset="/images/logo@2x.png 2x"
 				class="w-full h-full object-contain opacity-50"
 				alt="Sessionary Logo"
 			/>

--- a/frontend/src/lib/components/layout/NavBar.svelte
+++ b/frontend/src/lib/components/layout/NavBar.svelte
@@ -81,7 +81,7 @@
 		<a href="/home" class="h-full w-[134px] flex items-center justify-start">
 			<img
 				src="/images/logo.png"
-				srcset="/images/logo@2x.png 2x, /images/logo@3x.png 3x"
+				srcset="/images/logo@2x.png 2x"
 				class="h-full w-full object-contain transition-opacity duration-300"
 				alt="Sessionary Logo"
 			/>


### PR DESCRIPTION
## Summary
- NavBar와 Footer의 srcset에서 존재하지 않는 `logo@3x.png` 참조를 제거
- 모바일 기기(3x 디스플레이 밀도)에서 로고 이미지 404 에러 해결

## Changes
- `frontend/src/lib/components/layout/NavBar.svelte`: srcset에서 `logo@3x.png` 제거
- `frontend/src/lib/components/layout/Footer.svelte`: srcset에서 `logo@3x.png` 제거

## Test plan
- [ ] 모바일 브라우저에서 로고 이미지가 정상 표시되는지 확인
- [ ] PC 환경에서 기존 동작이 유지되는지 확인

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* 로고 이미지의 고해상도 디스플레이 지원이 변경되었습니다. 애플리케이션 곳곳에 표시되는 로고의 고픽셀 밀도 옵션이 조정되었으며, 기존 3배 고해상도 옵션이 제거되고 2배 해상도만 지원하게 됩니다. 매우 높은 픽셀 밀도의 디스플레이 기기에서 로고 표시 품질에 영향을 받을 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->