### PR TITLE
🐛 ticket_usage uq_user_lecture 잘못된 unique 제약 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 infra/scripts/setup-staging-secrets.sh
 
 backend/dev-scripts/*.sql
+scripts/
 sessionary.code-workspace
 .cursorrules
 .cursor/skills/rule/SKILL.md

--- a/backend/app/db/migrations/versions/2026_05_05_drop_uq_user_lecture.py
+++ b/backend/app/db/migrations/versions/2026_05_05_drop_uq_user_lecture.py
@@ -1,0 +1,25 @@
+"""drop uq_user_lecture unique constraint from ticket_usage
+
+ticket_usage는 티켓 사용 로그 테이블이므로 같은 (user_id, lecture_id)에 대해
+여러 row가 허용되어야 한다. 기존 unique constraint는 설계 오류.
+
+Revision ID: drop_uq_user_lecture_001
+Revises: add_session_fields_001
+Create Date: 2026-05-05
+
+"""
+
+from alembic import op
+
+revision = "drop_uq_user_lecture_001"
+down_revision = "add_session_fields_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_user_lecture", "ticket_usage", type_="unique")
+
+
+def downgrade() -> None:
+    op.create_unique_constraint("uq_user_lecture", "ticket_usage", ["user_id", "lecture_id"])

--- a/backend/app/db/migrations/versions/2026_05_05_drop_uq_user_lecture.py
+++ b/backend/app/db/migrations/versions/2026_05_05_drop_uq_user_lecture.py
@@ -22,4 +22,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # upgrade 이후 중복 (user_id, lecture_id) 행이 존재할 수 있으므로
+    # 각 쌍에서 가장 최근 행(used_at DESC)만 남기고 나머지를 삭제한다.
+    op.execute(
+        """
+        DELETE FROM ticket_usage
+        WHERE id NOT IN (
+            SELECT DISTINCT ON (user_id, lecture_id) id
+            FROM ticket_usage
+            ORDER BY user_id, lecture_id, used_at DESC
+        )
+        """
+    )
     op.create_unique_constraint("uq_user_lecture", "ticket_usage", ["user_id", "lecture_id"])

--- a/backend/app/db/tables.py
+++ b/backend/app/db/tables.py
@@ -19,7 +19,6 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
-    UniqueConstraint,
     func,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -263,6 +262,3 @@ class TicketUsage(Base):
     )
 
     __tablename__ = "ticket_usage"
-    __table_args__ = (
-        UniqueConstraint("user_id", "lecture_id", name="uq_user_lecture"),
-    )

--- a/backend/app/ticket/repository.py
+++ b/backend/app/ticket/repository.py
@@ -3,7 +3,7 @@ import datetime
 import uuid
 
 from fastapi import HTTPException
-from sqlalchemy import select, update
+from sqlalchemy import desc, select, update
 from sqlalchemy.orm import selectinload
 
 from app.db import tables as tb
@@ -49,11 +49,14 @@ class TicketRepository(BaseTicketRepository):
             now = datetime.datetime.now(datetime.timezone.utc)
             one_week_ago = now - datetime.timedelta(weeks=1)
             result = await session.execute(
-                select(tb.TicketUsage).where(
+                select(tb.TicketUsage)
+                .where(
                     tb.TicketUsage.user_id == user_id,
                     tb.TicketUsage.lecture_id == lecture_id,
                     tb.TicketUsage.used_at > one_week_ago,
                 )
+                .order_by(desc(tb.TicketUsage.used_at))
+                .limit(1)
             )
             return result.scalar_one_or_none()
 

--- a/backend/tests/api/test_ticket.py
+++ b/backend/tests/api/test_ticket.py
@@ -255,3 +255,54 @@ async def test_sut_use_ticket_returns_existing_when_already_used(
         )
         refreshed_user = result.scalar_one()
         assert refreshed_user.ticket_count == initial_count
+
+
+@pytest.fixture
+async def expired_ticket(
+    test_user: User, dummy_lecture: Lecture, test_session: AsyncSession
+) -> TicketUsage:
+    ticket_usage = TicketUsage(
+        user_id=test_user.id,
+        lecture_id=dummy_lecture.id,
+        used_at=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(weeks=2),
+    )
+    async with test_session.begin():
+        test_session.add(ticket_usage)
+        await test_session.flush()
+    await test_session.commit()
+    return ticket_usage
+
+
+async def test_sut_use_ticket_succeeds_when_old_ticket_expired(
+    authorized_client: AsyncClient,
+    dummy_lecture: Lecture,
+    expired_ticket: TicketUsage,
+    test_user: User,
+    test_session: AsyncSession,
+):
+    """만료된 ticket_usage(>1주)가 있을 때 재사용 시도 → 새 ticket 소비 후 accessible=True"""
+    from app.db.tables import User as UserTable, TicketUsage as TicketUsageTable
+
+    initial_count = test_user.ticket_count
+    response = await authorized_client.post(f"/ticket/lecture/{dummy_lecture.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["accessible"] is True
+    assert data["reason"] == "ticket_used"
+    assert data["expires_at"] is not None
+
+    async with test_session.begin():
+        result = await test_session.execute(
+            select(UserTable).where(UserTable.id == test_user.id)
+        )
+        refreshed_user = result.scalar_one()
+        assert refreshed_user.ticket_count == initial_count - 1
+
+        usage_result = await test_session.execute(
+            select(TicketUsageTable).where(
+                TicketUsageTable.user_id == test_user.id,
+                TicketUsageTable.lecture_id == dummy_lecture.id,
+            )
+        )
+        usages = usage_result.scalars().all()
+        assert len(usages) == 2


### PR DESCRIPTION
## Summary

- `ticket_usage` 테이블의 `uq_user_lecture(user_id, lecture_id)` unique constraint는 설계 오류
- 해당 테이블은 티켓 사용 **로그** 테이블이므로 동일 강의에 여러 row가 허용되어야 함
- 기존 제약으로 인해 만료된 티켓(>1주) 재사용 시 `UniqueViolationError` 500 에러 발생

## Changes

- **migration**: `uq_user_lecture` unique constraint DROP
- **tables.py**: `UniqueConstraint` 제거
- **repository.py**: `get_ticket_usage`에 `order_by(desc).limit(1)` 추가 (다중 row 환경 안전 처리)
- **service.py**: 원래 `get_ticket_usage` 기반 로직 유지 (변경 없음)
- **test**: 만료 후 재사용 → 새 티켓 소비 + `accessible=True` + row 2개 검증

## Test plan

- [x] `uv run pytest tests/api/test_ticket.py` — 10 passed
- [ ] staging DB에서 migration 적용 확인
- [ ] 실제 만료 티켓 사용자로 `POST /ticket/lecture/{id}` 동작 확인

Closes #: staging 500 에러 (2026-05-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 사용자가 만료된 티켓으로 동일 강좌에 대해 새 티켓을 사용할 수 있도록 수정
  * 티켓 사용 시 가장 최근의 사용 기록을 확인하도록 개선

* **Tests**
  * 만료된 티켓 재사용 시나리오에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->