### PR TITLE
🔧 OpenAPI 계약 스냅샷 + 모노레포 통합 러너로 QA/E2E 운용성 개선

### DIFF
--- a/.github/workflows/2-test-backend.yml
+++ b/.github/workflows/2-test-backend.yml
@@ -21,6 +21,10 @@ jobs:
         working-directory: ./backend
         run: uv sync --frozen
 
+      - name: Verify OpenAPI snapshot matches code
+        working-directory: ./backend
+        run: uv run python dev-scripts/export_openapi.py --check
+
       - name: Run the tests
         working-directory: ./backend
         run: uv run pytest -v tests

--- a/.github/workflows/2-test-frontend.yml
+++ b/.github/workflows/2-test-frontend.yml
@@ -4,6 +4,8 @@ on:
     types: [ready_for_review, synchronize]
     paths:
       - "frontend/**"
+      # 백엔드 OpenAPI 계약(스냅샷)이 바뀌면 client 동기화 검증을 위해 실행
+      - "backend/openapi.json"
 jobs:
   fe-test:
     timeout-minutes: 60
@@ -20,6 +22,13 @@ jobs:
       - name: Install dependencies
         working-directory: ./frontend
         run: npm i -g yarn &&  yarn install --frozen-lockfile
+
+      - name: Verify API client matches backend OpenAPI snapshot
+        working-directory: ./frontend
+        run: |
+          yarn generate-client
+          git diff --exit-code src/lib/api/client \
+            || (echo "::error::API client out of sync with backend/openapi.json. Run 'yarn generate-client' and commit." && exit 1)
 
       - name: Sync SvelteKit
         working-directory: ./frontend

--- a/.github/workflows/2-test-frontend.yml
+++ b/.github/workflows/2-test-frontend.yml
@@ -27,8 +27,12 @@ jobs:
         working-directory: ./frontend
         run: |
           yarn generate-client
-          git diff --exit-code src/lib/api/client \
-            || (echo "::error::API client out of sync with backend/openapi.json. Run 'yarn generate-client' and commit." && exit 1)
+          # --porcelain 은 수정(M)뿐 아니라 신규 생성된 untracked(??) 파일도 감지한다.
+          if [ -n "$(git status --porcelain src/lib/api/client)" ]; then
+            echo "::error::API client out of sync with backend/openapi.json. Run 'yarn generate-client' and commit."
+            git status --porcelain src/lib/api/client
+            exit 1
+          fi
 
       - name: Sync SvelteKit
         working-directory: ./frontend

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+# Sessionary 모노레포 통합 러너
+#
+# frontend(yarn) / backend(uv) 가 서로 다른 툴체인을 쓰므로, 디렉토리를 옮겨
+# 다니지 않고 루트에서 한 번에 실행하기 위한 얇은 위임 레이어다.
+# (소스를 통합하는 것이 아니라 "어디서 무엇을 치는지"만 모은다.)
+
+.PHONY: help install \
+        test test-be test-fe test-unit test-e2e \
+        export-spec gen-client check-spec \
+        lint format check
+
+help: ## 사용 가능한 명령 목록
+	@echo "Sessionary 통합 명령:"
+	@echo "  make install      - fe/be 의존성 설치"
+	@echo "  make test         - 백엔드 + 프론트엔드 전체 테스트"
+	@echo "  make test-be      - 백엔드 pytest"
+	@echo "  make test-fe      - 프론트엔드 유닛 + e2e"
+	@echo "  make test-unit    - 프론트엔드 Vitest 유닛"
+	@echo "  make test-e2e     - 프론트엔드 Playwright e2e (백엔드는 mock)"
+	@echo "  make export-spec  - 백엔드 OpenAPI 스냅샷(backend/openapi.json) 생성"
+	@echo "  make gen-client   - 스냅샷 생성 + 프론트 API client 재생성"
+	@echo "  make check-spec   - 계약 drift 검증 (be 코드↔스냅샷, fe 스냅샷↔client)"
+	@echo "  make check        - 프론트 타입체크(svelte-check)"
+	@echo "  make lint         - fe/be 린트"
+	@echo "  make format       - fe/be 포맷"
+
+install: ## fe/be 의존성 설치
+	cd backend && uv sync
+	cd frontend && yarn install
+
+# --- 테스트 -----------------------------------------------------------------
+
+test: test-be test-fe ## 전체 테스트
+
+test-be: ## 백엔드 pytest
+	cd backend && uv run pytest -v tests
+
+test-fe: test-unit test-e2e ## 프론트엔드 전체 (유닛 + e2e)
+
+test-unit: ## 프론트엔드 Vitest 유닛 (non-watch)
+	cd frontend && yarn vitest run
+
+test-e2e: ## 프론트엔드 Playwright e2e — 백엔드는 page.route 로 mock
+	cd frontend && yarn playwright test
+
+# --- OpenAPI 계약 -----------------------------------------------------------
+
+export-spec: ## 백엔드 OpenAPI 스냅샷 생성
+	cd backend && uv run python dev-scripts/export_openapi.py
+
+gen-client: export-spec ## 스냅샷 생성 + 프론트 client 재생성
+	cd frontend && yarn generate-client
+
+check-spec: ## 계약 drift 검증 (CI 와 동일)
+	cd backend && uv run python dev-scripts/export_openapi.py --check
+	cd frontend && yarn generate-client && git diff --exit-code src/lib/api/client \
+		|| (echo "API client 가 backend/openapi.json 과 다릅니다. 'make gen-client' 후 커밋하세요." && exit 1)
+
+# --- 품질 -------------------------------------------------------------------
+
+check: ## 프론트 타입체크
+	cd frontend && yarn run check
+
+lint: ## fe/be 린트
+	cd backend && uv run ruff check .
+	cd frontend && yarn lint
+
+format: ## fe/be 포맷
+	cd backend && uv run ruff format .
+	cd frontend && yarn format

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,12 @@ gen-client: export-spec ## 스냅샷 생성 + 프론트 client 재생성
 
 check-spec: ## 계약 drift 검증 (CI 와 동일)
 	cd backend && uv run python dev-scripts/export_openapi.py --check
-	cd frontend && yarn generate-client && git diff --exit-code src/lib/api/client \
-		|| (echo "API client 가 backend/openapi.json 과 다릅니다. 'make gen-client' 후 커밋하세요." && exit 1)
+	cd frontend && yarn generate-client
+	@if [ -n "$$(git status --porcelain frontend/src/lib/api/client)" ]; then \
+		echo "API client 가 backend/openapi.json 과 다릅니다. 'make gen-client' 후 커밋하세요."; \
+		git status --porcelain frontend/src/lib/api/client; \
+		exit 1; \
+	fi
 
 # --- 품질 -------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,22 @@
 ## Description
 Sessionary is an online lecture service focusing on worship/band sessions.
 Our platform provides a unique learning experience for musicians and worship leaders, offering a variety of courses and resources to enhance musical skills and knowledge.
+
+## Monorepo
+
+- `frontend/` — SvelteKit (yarn)
+- `backend/` — FastAPI (uv)
+
+서로 다른 툴체인을 루트에서 한 번에 다루기 위한 `make` 명령을 제공한다.
+
+```bash
+make install      # fe/be 의존성 설치
+make test         # 백엔드 + 프론트 전체 테스트
+make test-e2e     # 프론트 E2E (백엔드는 mock)
+make gen-client   # OpenAPI 스냅샷 + API client 재생성
+make check-spec   # fe/be 계약 drift 검증
+make help         # 전체 명령
+```
+
+- 테스트 전략(계층 책임 / mock): [docs/testing.md](docs/testing.md)
+- 빌드·실행 상세: [docs/domain/build-test.md](docs/domain/build-test.md)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Sessionary
 
-## Description
-Sessionary is an online lecture service focusing on worship/band sessions.
-Our platform provides a unique learning experience for musicians and worship leaders, offering a variety of courses and resources to enhance musical skills and knowledge.
+## 소개
+Sessionary는 워십/밴드 세션에 초점을 맞춘 온라인 강의 서비스입니다.
+음악가와 워십 리더에게 차별화된 학습 경험을 제공하며, 음악 실력과 지식을 키울 수 있는 다양한 강의와 리소스를 제공합니다.
 
-## Monorepo
+## 모노레포
 
 - `frontend/` — SvelteKit (yarn)
 - `backend/` — FastAPI (uv)

--- a/backend/dev-scripts/export_openapi.py
+++ b/backend/dev-scripts/export_openapi.py
@@ -1,0 +1,70 @@
+"""OpenAPI 스펙을 backend/openapi.json 스냅샷으로 export 한다.
+
+이 스냅샷이 프론트엔드 API client(openapi-ts) 생성의 단일 진실 소스다.
+백엔드를 띄우지 않고 app 객체에서 직접 스펙을 뽑으므로 DB/네트워크 의존이 없다.
+
+사용법:
+    uv run python dev-scripts/export_openapi.py
+    uv run python dev-scripts/export_openapi.py --check   # 재생성 후 diff 없으면 0, 있으면 1
+
+`--check` 는 CI 에서 "백엔드 코드와 커밋된 스펙이 동기화되어 있는가"를 검증한다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from os import environ
+from pathlib import Path
+import sys
+
+# app 객체만 생성하면 되므로 DB 연결이 필요 없는 test 설정을 사용한다.
+# (TestAppSettings 가 모든 required 필드에 기본값을 제공)
+environ.setdefault("APP_ENV", "test")
+
+from app.main import get_application  # noqa: E402
+
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "openapi.json"
+
+
+def build_spec() -> str:
+    app = get_application()
+    spec = app.openapi()
+    # FastAPI 의 출력은 코드 정의 순서를 따르는 결정적 순서다. 일부러 정렬하지
+    # 않아(sort_keys=False) 라이브 스펙과 동일한 순서를 유지하고, client 도 그
+    # 순서대로 생성되어 무의미한 대량 diff 를 피한다. trailing newline 만 보장한다.
+    return json.dumps(spec, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export OpenAPI spec snapshot")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="재생성 결과가 커밋된 파일과 다르면 비정상 종료(1)",
+    )
+    args = parser.parse_args()
+
+    spec = build_spec()
+
+    if args.check:
+        if not OUTPUT_PATH.exists():
+            print(f"[export_openapi] {OUTPUT_PATH} 가 없습니다. 먼저 생성하세요.")
+            return 1
+        current = OUTPUT_PATH.read_text(encoding="utf-8")
+        if current != spec:
+            print(
+                "[export_openapi] openapi.json 이 백엔드 코드와 다릅니다. "
+                "`uv run python dev-scripts/export_openapi.py` 후 커밋하세요."
+            )
+            return 1
+        print("[export_openapi] openapi.json 동기화 확인됨.")
+        return 0
+
+    OUTPUT_PATH.write_text(spec, encoding="utf-8")
+    print(f"[export_openapi] {OUTPUT_PATH} 생성 완료.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,2091 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sessionary Backend Server",
+    "version": "0.0.0"
+  },
+  "paths": {
+    "/user/artists": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get Artists",
+        "operationId": "get_artists_user_artists_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetArtistsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Auth:Redis.Login",
+        "operationId": "auth_redis_login_user_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_auth_redis_login_user_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                },
+                "examples": {
+                  "LOGIN_BAD_CREDENTIALS": {
+                    "summary": "Bad credentials or the user is inactive.",
+                    "value": {
+                      "detail": "LOGIN_BAD_CREDENTIALS"
+                    }
+                  },
+                  "LOGIN_USER_NOT_VERIFIED": {
+                    "summary": "The user is not verified.",
+                    "value": {
+                      "detail": "LOGIN_USER_NOT_VERIFIED"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Auth:Redis.Logout",
+        "operationId": "auth_redis_logout_user_auth_logout_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          }
+        ]
+      }
+    },
+    "/user/auth/forgot-password": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Reset:Forgot Password",
+        "operationId": "reset_forgot_password_user_auth_forgot_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_reset_forgot_password_user_auth_forgot_password_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/auth/reset-password": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Reset:Reset Password",
+        "operationId": "reset_reset_password_user_auth_reset_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_reset_reset_password_user_auth_reset_password_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                },
+                "examples": {
+                  "RESET_PASSWORD_BAD_TOKEN": {
+                    "summary": "Bad or expired token.",
+                    "value": {
+                      "detail": "RESET_PASSWORD_BAD_TOKEN"
+                    }
+                  },
+                  "RESET_PASSWORD_INVALID_PASSWORD": {
+                    "summary": "Password validation failed.",
+                    "value": {
+                      "detail": {
+                        "code": "RESET_PASSWORD_INVALID_PASSWORD",
+                        "reason": "Password should be at least 3 characters"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/oauth/google/authorize": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Oauth:Google.Redis.Authorize",
+        "operationId": "oauth_google_redis_authorize_user_oauth_google_authorize_get",
+        "parameters": [
+          {
+            "name": "scopes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Scopes"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuth2AuthorizeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/oauth/google/callback": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Oauth:Google.Redis.Callback",
+        "description": "The response varies based on the authentication backend used.",
+        "operationId": "oauth_google_redis_callback_user_oauth_google_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Code"
+            }
+          },
+          {
+            "name": "code_verifier",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Code Verifier"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "State"
+            }
+          },
+          {
+            "name": "error",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Error"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "INVALID_STATE_TOKEN": {
+                    "summary": "Invalid state token."
+                  },
+                  "LOGIN_BAD_CREDENTIALS": {
+                    "summary": "User is inactive.",
+                    "value": {
+                      "detail": "LOGIN_BAD_CREDENTIALS"
+                    }
+                  },
+                  "ACCESS_TOKEN_DECODE_ERROR": {
+                    "summary": "Access token is error.",
+                    "value": {
+                      "detail": "ACCESS_TOKEN_DECODE_ERROR"
+                    }
+                  },
+                  "ACCESS_TOKEN_ALREADY_EXPIRED": {
+                    "summary": "Access token is already expired.",
+                    "value": {
+                      "detail": "ACCESS_TOKEN_ALREADY_EXPIRED"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/me": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Users:Current User",
+        "operationId": "users_current_user_user_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Users:Patch Current User",
+        "operationId": "users_patch_current_user_user_me_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                },
+                "examples": {
+                  "UPDATE_USER_EMAIL_ALREADY_EXISTS": {
+                    "summary": "A user with this email already exists.",
+                    "value": {
+                      "detail": "UPDATE_USER_EMAIL_ALREADY_EXISTS"
+                    }
+                  },
+                  "UPDATE_USER_INVALID_PASSWORD": {
+                    "summary": "Password validation failed.",
+                    "value": {
+                      "detail": {
+                        "code": "UPDATE_USER_INVALID_PASSWORD",
+                        "reason": "Password should beat least 3 characters"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          }
+        ]
+      }
+    },
+    "/user/{id}": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Users:User",
+        "operationId": "users_user_user__id__get",
+        "security": [
+          {
+            "APIKeyCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "403": {
+            "description": "Not a superuser."
+          },
+          "404": {
+            "description": "The user does not exist."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Users:Patch User",
+        "operationId": "users_patch_user_user__id__patch",
+        "security": [
+          {
+            "APIKeyCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "403": {
+            "description": "Not a superuser."
+          },
+          "404": {
+            "description": "The user does not exist."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "UPDATE_USER_EMAIL_ALREADY_EXISTS": {
+                    "summary": "A user with this email already exists.",
+                    "value": {
+                      "detail": "UPDATE_USER_EMAIL_ALREADY_EXISTS"
+                    }
+                  },
+                  "UPDATE_USER_INVALID_PASSWORD": {
+                    "summary": "Password validation failed.",
+                    "value": {
+                      "detail": {
+                        "code": "UPDATE_USER_INVALID_PASSWORD",
+                        "reason": "Password should beat least 3 characters"
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Users:Delete User",
+        "operationId": "users_delete_user_user__id__delete",
+        "security": [
+          {
+            "APIKeyCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "403": {
+            "description": "Not a superuser."
+          },
+          "404": {
+            "description": "The user does not exist."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lecture": {
+      "get": {
+        "tags": [
+          "lecture"
+        ],
+        "summary": "Get Lectures",
+        "operationId": "get_lectures_lecture_get",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 10,
+              "default": 20,
+              "title": "Per Page"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchRecommendedLecuturesSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "lecture"
+        ],
+        "summary": "Create Lecture",
+        "operationId": "create_lecture_lecture_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLectureBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateLectureResponseSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lecture/{lecture_id}": {
+      "get": {
+        "tags": [
+          "lecture"
+        ],
+        "summary": "Get Lecture",
+        "operationId": "get_lecture_lecture__lecture_id__get",
+        "parameters": [
+          {
+            "name": "lecture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lecture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetLectureSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lesson/{lesson_id}/video": {
+      "get": {
+        "tags": [
+          "lesson"
+        ],
+        "summary": "Get Lesson Video",
+        "operationId": "get_lesson_video_lesson__lesson_id__video_get",
+        "parameters": [
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lesson Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VideoURLResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/session/{session_id}": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "summary": "Get Session Detail",
+        "operationId": "get_session_detail_session__session_id__get",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ticket/lecture/{lecture_id}": {
+      "get": {
+        "tags": [
+          "ticket"
+        ],
+        "summary": "Get Lecture Access Status",
+        "operationId": "get_lecture_access_status_ticket_lecture__lecture_id__get",
+        "parameters": [
+          {
+            "name": "lecture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lecture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LectureAccessStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ticket"
+        ],
+        "summary": "Use Ticket",
+        "operationId": "use_ticket_ticket_lecture__lecture_id__post",
+        "parameters": [
+          {
+            "name": "lecture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lecture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LectureAccessStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ping": {
+      "get": {
+        "tags": [
+          "ping"
+        ],
+        "summary": "Pong",
+        "operationId": "pong_ping_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ping/auth": {
+      "get": {
+        "tags": [
+          "ping"
+        ],
+        "summary": "Auth Pong",
+        "operationId": "auth_pong_ping_auth_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ArtistInfoInLecture": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "nickname": {
+            "type": "string",
+            "title": "Nickname"
+          },
+          "is_artist": {
+            "type": "boolean",
+            "title": "Is Artist"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "nickname",
+          "is_artist"
+        ],
+        "title": "ArtistInfoInLecture"
+      },
+      "Body_auth_redis_login_user_auth_login_post": {
+        "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "format": "password",
+            "title": "Client Secret"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_auth_redis_login_user_auth_login_post"
+      },
+      "Body_reset_forgot_password_user_auth_forgot_password_post": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "title": "Body_reset_forgot_password_user_auth_forgot_password_post"
+      },
+      "Body_reset_reset_password_user_auth_reset_password_post": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "password"
+        ],
+        "title": "Body_reset_reset_password_user_auth_reset_password_post"
+      },
+      "CreateLectureBody": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": "새로운 강의"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "CreateLectureBody"
+      },
+      "CreateLectureResponseSchema": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/LectureDetail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateLectureResponseSchema"
+      },
+      "ErrorModel": {
+        "properties": {
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            ],
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorModel"
+      },
+      "FetchRecommendedLecuturesSchema": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LectureInList"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "FetchRecommendedLecuturesSchema"
+      },
+      "GetArtistsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/UserArtistInfo"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GetArtistsResponse"
+      },
+      "GetLectureSchema": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/LectureDetail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GetLectureSchema"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "LectureAccessStatus": {
+        "properties": {
+          "accessible": {
+            "type": "boolean",
+            "title": "Accessible"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "unlimited",
+                  "ticket_used",
+                  "no_ticket",
+                  "ticket_expired"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "ticket_count": {
+            "type": "integer",
+            "title": "Ticket Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accessible",
+          "ticket_count"
+        ],
+        "title": "LectureAccessStatus"
+      },
+      "LectureDetail": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtistInfoInLecture"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lessons": {
+            "items": {
+              "$ref": "#/components/schemas/LessonInLecture"
+            },
+            "type": "array",
+            "title": "Lessons"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "thumbnail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "원곡카피",
+                      "해석버전",
+                      "기본기"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Easy",
+                      "Intermediate",
+                      "Advanced"
+                    ]
+                  }
+                ],
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "length_sec": {
+            "type": "integer",
+            "title": "Length Sec"
+          },
+          "lecture_count": {
+            "type": "integer",
+            "title": "Lecture Count"
+          },
+          "time_created": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Created"
+          },
+          "time_updated": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "artist",
+          "lessons",
+          "description",
+          "thumbnail",
+          "tags",
+          "length_sec",
+          "lecture_count",
+          "time_created",
+          "time_updated"
+        ],
+        "title": "LectureDetail"
+      },
+      "LectureInList": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "thumbnail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtistInfoInLecture"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lessons": {
+            "items": {
+              "$ref": "#/components/schemas/LessonInLecture"
+            },
+            "type": "array",
+            "title": "Lessons"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "원곡카피",
+                      "해석버전",
+                      "기본기"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Easy",
+                      "Intermediate",
+                      "Advanced"
+                    ]
+                  }
+                ],
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "length_sec": {
+            "type": "integer",
+            "title": "Length Sec"
+          },
+          "lecture_count": {
+            "type": "integer",
+            "title": "Lecture Count"
+          },
+          "time_created": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Created"
+          },
+          "time_updated": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "thumbnail",
+          "title",
+          "artist",
+          "lessons",
+          "description",
+          "tags",
+          "length_sec",
+          "lecture_count",
+          "time_created",
+          "time_updated"
+        ],
+        "title": "LectureInList"
+      },
+      "LectureInfo": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "total_sessions": {
+            "type": "integer",
+            "title": "Total Sessions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "total_sessions"
+        ],
+        "title": "LectureInfo"
+      },
+      "LessonInLecture": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "length_sec": {
+            "type": "integer",
+            "title": "Length Sec"
+          },
+          "lecture_ordering": {
+            "type": "integer",
+            "title": "Lecture Ordering"
+          },
+          "time_created": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Created"
+          },
+          "time_updated": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "length_sec",
+          "lecture_ordering",
+          "time_created",
+          "time_updated"
+        ],
+        "title": "LessonInLecture"
+      },
+      "OAuth2AuthorizeResponse": {
+        "properties": {
+          "authorization_url": {
+            "type": "string",
+            "title": "Authorization Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "authorization_url"
+        ],
+        "title": "OAuth2AuthorizeResponse"
+      },
+      "PaginationMeta": {
+        "properties": {
+          "total_items": {
+            "type": "integer",
+            "title": "Total Items"
+          },
+          "total_pages": {
+            "type": "integer",
+            "title": "Total Pages"
+          },
+          "curr_page": {
+            "type": "integer",
+            "title": "Curr Page"
+          },
+          "per_page": {
+            "type": "integer",
+            "title": "Per Page"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total_items",
+          "total_pages",
+          "curr_page",
+          "per_page"
+        ],
+        "title": "PaginationMeta"
+      },
+      "PlayingGuideStep": {
+        "properties": {
+          "step": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Step"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "start_time": {
+            "type": "string",
+            "title": "Start Time"
+          },
+          "end_time": {
+            "type": "string",
+            "title": "End Time"
+          },
+          "tip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tip"
+          }
+        },
+        "type": "object",
+        "required": [
+          "step",
+          "title",
+          "description",
+          "start_time",
+          "end_time"
+        ],
+        "title": "PlayingGuideStep"
+      },
+      "SessionDetailResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "session_type": {
+            "$ref": "#/components/schemas/SessionType"
+          },
+          "session_type_label": {
+            "type": "string",
+            "title": "Session Type Label"
+          },
+          "lecture_ordering": {
+            "type": "integer",
+            "title": "Lecture Ordering"
+          },
+          "length_sec": {
+            "type": "integer",
+            "title": "Length Sec"
+          },
+          "lecture": {
+            "$ref": "#/components/schemas/LectureInfo"
+          },
+          "video": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VideoInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sheetmusic_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sheetmusic Url"
+          },
+          "sync_offset": {
+            "type": "integer",
+            "title": "Sync Offset"
+          },
+          "subtitles": {
+            "items": {
+              "$ref": "#/components/schemas/Subtitle"
+            },
+            "type": "array",
+            "title": "Subtitles"
+          },
+          "playing_guide": {
+            "items": {
+              "$ref": "#/components/schemas/PlayingGuideStep"
+            },
+            "type": "array",
+            "title": "Playing Guide"
+          },
+          "navigation": {
+            "$ref": "#/components/schemas/SessionNavigation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "session_type",
+          "session_type_label",
+          "lecture_ordering",
+          "length_sec",
+          "lecture",
+          "video",
+          "sheetmusic_url",
+          "sync_offset",
+          "subtitles",
+          "playing_guide",
+          "navigation"
+        ],
+        "title": "SessionDetailResponse"
+      },
+      "SessionNavigation": {
+        "properties": {
+          "prev_session_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Session Id"
+          },
+          "next_session_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Session Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prev_session_id",
+          "next_session_id"
+        ],
+        "title": "SessionNavigation"
+      },
+      "SessionType": {
+        "type": "string",
+        "enum": [
+          "PLAY",
+          "TALK",
+          "JAM",
+          "BASIC",
+          "SHEET"
+        ],
+        "title": "SessionType"
+      },
+      "Subtitle": {
+        "properties": {
+          "timestamp_ms": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Timestamp Ms"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "timestamp_ms",
+          "text"
+        ],
+        "title": "Subtitle"
+      },
+      "UserArtistInfo": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "nickname": {
+            "type": "string",
+            "title": "Nickname"
+          },
+          "time_created": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Time Created"
+          },
+          "lectures": {
+            "items": {
+              "$ref": "#/components/schemas/LectureInList"
+            },
+            "type": "array",
+            "title": "Lectures"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "nickname",
+          "time_created",
+          "lectures"
+        ],
+        "title": "UserArtistInfo"
+      },
+      "UserRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
+          },
+          "is_superuser": {
+            "type": "boolean",
+            "title": "Is Superuser"
+          },
+          "is_verified": {
+            "type": "boolean",
+            "title": "Is Verified",
+            "default": false
+          },
+          "nickname": {
+            "type": "string",
+            "title": "Nickname"
+          },
+          "is_artist": {
+            "type": "boolean",
+            "title": "Is Artist"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "is_superuser",
+          "nickname",
+          "is_artist"
+        ],
+        "title": "UserRead"
+      },
+      "UserUpdate": {
+        "properties": {
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
+          },
+          "is_superuser": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Superuser"
+          },
+          "is_verified": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Verified"
+          },
+          "nickname": {
+            "type": "string",
+            "title": "Nickname"
+          }
+        },
+        "type": "object",
+        "required": [
+          "nickname"
+        ],
+        "title": "UserUpdate"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VideoInfo": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "type",
+          "expires_at"
+        ],
+        "title": "VideoInfo"
+      },
+      "VideoURLResponse": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "hls",
+              "direct"
+            ],
+            "title": "Type"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "type",
+          "expires_at"
+        ],
+        "title": "VideoURLResponse"
+      }
+    },
+    "securitySchemes": {
+      "APIKeyCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "satk"
+      }
+    }
+  }
+}

--- a/docs/domain/build-test.md
+++ b/docs/domain/build-test.md
@@ -40,10 +40,13 @@
 |------|------|
 | `yarn install` | 의존성 설치 |
 | `yarn build` | 프로덕션 빌드 |
-| `yarn generate-client` | OpenAPI 클라이언트 재생성 |
+| `yarn generate-client` | OpenAPI 클라이언트 재생성 (`backend/openapi.json` 스냅샷 기반) |
 | `docker build -f frontend/Dockerfile .` | Docker 이미지 빌드 |
 
 ## 테스트 명령
+
+> 계층별 책임(유닛 / E2E+mock / 백엔드 계약)과 mock 전략은 [../testing.md](../testing.md) 참고.
+> 루트에서 통합 실행하려면 `make test` / `make test-be` / `make test-e2e` 등을 쓴다.
 
 ### Backend
 
@@ -77,8 +80,8 @@
 
 | 워크플로 | 트리거 | 내용 |
 |----------|--------|------|
-| `2-test-backend.yml` | PR → `backend/**` | Python 3.11, uv, pytest |
-| `2-test-frontend.yml` | PR → `frontend/**` | Node 20, Yarn, Playwright + Vitest |
+| `2-test-backend.yml` | PR → `backend/**` | Python 3.11, uv, OpenAPI 스냅샷 검증, pytest |
+| `2-test-frontend.yml` | PR → `frontend/**` 또는 `backend/openapi.json` | Node 20, Yarn, API client 동기화 검증, Playwright + Vitest |
 | `deploy-staging-backend.yml` | main 머지 → `backend/**` 또는 `infra/**` | flyctl로 스테이징 배포 후 헬스체크 |
 | `deploy-staging-frontend.yml` | main 머지 → `frontend/**` 또는 `infra/**` | flyctl로 스테이징 배포 후 헬스체크 |
 
@@ -125,7 +128,17 @@ yarn dev  # http://localhost:5173
 ```
 
 ### API 클라이언트 재생성
+프론트 client 는 라이브 백엔드가 아니라 커밋된 스냅파일 `backend/openapi.json`
+에서 생성된다. 백엔드 응답 계약을 바꿨다면 스냅샷부터 재생성한다.
+
 ```bash
-cd frontend
-yarn generate-client  # 백엔드 서버가 실행 중이어야 함
+# 루트에서 한 번에 (스냅샷 + client 재생성)
+make gen-client
+make check-spec   # drift 없는지 검증 (CI 와 동일)
+
+# 개별 실행
+cd backend && uv run python dev-scripts/export_openapi.py  # 스냅샷 갱신
+cd frontend && yarn generate-client                        # 백엔드 불필요
 ```
+
+`backend/openapi.json` 과 `frontend/src/lib/api/client` 를 함께 커밋한다.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,80 @@
+# 테스트 전략
+
+모노레포(`frontend` + `backend`)의 테스트 계층과 그 책임 경계를 정의한다.
+실행 명령은 [domain/build-test.md](domain/build-test.md) 또는 루트 `make` 를 참고한다.
+
+## 한눈에 보기
+
+| 계층 | 도구 | 위치 | 백엔드 | 책임 |
+|------|------|------|--------|------|
+| 백엔드 단위/통합 | pytest | `backend/tests` | 실제(SQLite) | **API 계약의 진실 소스** |
+| 프론트 유닛 | Vitest | `frontend/tests/unit` | 없음 | 순수 로직 / 컴포넌트 단위 |
+| 프론트 E2E | Playwright | `frontend/tests` | **mock** | 유저 플로우 / UI 상태 전이 |
+
+핵심 원칙: **E2E 는 프론트엔드에 두고 백엔드를 mock 한다.** 실제 백엔드를 띄우지
+않으므로 빠르고 결정적이며, CI 에서 프론트 job 이 백엔드에 의존하지 않는다.
+
+## 계층별 책임
+
+### 1. 백엔드 (pytest) — 계약의 진실 소스
+- 실제 응답 shape, 상태 코드, 인증/권한 규칙을 검증한다.
+- E2E 의 mock 은 "백엔드가 이렇게 응답한다"는 **가정**이다. 그 가정이 실제와
+  같다는 보증은 오직 여기서 나온다.
+- 따라서 응답 계약이 바뀌면 반드시 여기 테스트가 먼저 바뀌어야 한다.
+
+### 2. 프론트 유닛 (Vitest)
+- 네트워크/렌더링에 의존하지 않는 순수 로직(파서, 포매터, 스토어 등)과
+  좁은 범위의 컴포넌트 단위를 검증한다.
+- 백엔드 호출이 필요하면 그 테스트는 유닛이 아니라 E2E 계층으로 올린다.
+
+### 3. 프론트 E2E (Playwright) — 백엔드 mock
+- 실제 사용자 플로우(로그인, 세션 진입, 권한 분기 등)와 UI 상태 전이를 검증한다.
+- 백엔드 응답은 `page.route('**/localhost:8000/**')` 로 가로채 mock 한다
+  ([tests/helpers/api-mocks.ts](../frontend/tests/helpers/api-mocks.ts)).
+- 이 구조가 동작하는 이유: **데이터 페칭이 전부 클라이언트사이드**다. SvelteKit
+  `load`(예: `session/[id]/+page.ts`)는 라우팅 파라미터만 계산하고, 실제 API
+  호출은 브라우저에서 일어난다. 그래서 `page.route` 가 모든 백엔드 호출을
+  가로챌 수 있다. (서버사이드 `load` 에서 fetch 하면 가로채지 못하므로, 새
+  데이터 로딩을 추가할 때 이 전제를 깨지 않도록 주의한다.)
+
+## mock 의 정확성을 지키는 법 — 계약 스냅샷
+
+mock 기반 E2E 의 유일한 맹점은 **"mock 이 실제 백엔드와 다를 수 있다"** 는 것이다.
+이를 구조적으로 막기 위해 OpenAPI 계약을 스냅샷으로 고정한다.
+
+```
+backend 코드 ──(export)──> backend/openapi.json ──(openapi-ts)──> 프론트 API client
+                              (단일 진실 소스)                        types.gen.ts 등
+                                                                         │
+                                          mock factory 가 이 타입을 사용 ─┘
+```
+
+- 백엔드는 `backend/openapi.json` 을 커밋된 스냅샷으로 export 한다
+  (`make export-spec`). 프론트 client 는 라이브 URL 이 아니라 이 파일에서 생성된다.
+- mock factory([api-mocks.ts](../frontend/tests/helpers/api-mocks.ts))는 생성된
+  타입(`types.gen.ts`)을 사용하므로, 백엔드 응답 shape 가 바뀌면 타입이 바뀌고
+  mock 도 컴파일 단계에서 깨진다 → silent drift 차단.
+- CI 가드:
+  - 백엔드: `export_openapi.py --check` 로 **코드 ↔ 스냅샷** 동기화 검증
+  - 프론트: client 재생성 후 `git diff --exit-code` 로 **스냅샷 ↔ client** 검증
+
+### 계약을 바꿀 때 워크플로우
+```bash
+# 백엔드 응답/스키마를 수정한 뒤
+make gen-client      # 스냅샷 재생성 + 프론트 client 재생성
+make check-spec      # drift 없는지 검증 (CI 와 동일)
+# backend/openapi.json + frontend/src/lib/api/client 를 함께 커밋
+```
+빠뜨리면 CI 가 빨갛게 된다.
+
+## 실행 (루트 통합)
+
+| 명령 | 내용 |
+|------|------|
+| `make test` | 백엔드 + 프론트 전체 |
+| `make test-be` | 백엔드 pytest |
+| `make test-e2e` | 프론트 E2E (백엔드 mock) |
+| `make test-unit` | 프론트 Vitest 유닛 |
+| `make check-spec` | 계약 drift 검증 |
+
+개별 도구 직접 실행은 [domain/build-test.md](domain/build-test.md) 참고.

--- a/frontend/openapi-ts.config.ts
+++ b/frontend/openapi-ts.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from '@hey-api/openapi-ts'
 
 export default defineConfig({
-	input: 'http://localhost:8000/openapi.json',
+	// 라이브 백엔드 대신 커밋된 스펙 스냅샷을 단일 진실 소스로 사용한다.
+	// 백엔드 응답 계약이 바뀌면 `backend/openapi.json` 을 재생성·커밋해야 하고,
+	// 그래야 client 타입이 따라 갱신된다. (CI 가 양쪽 drift 를 검증)
+	input: '../backend/openapi.json',
 	output: './src/lib/api/client',
 	client: 'axios'
 })

--- a/frontend/src/lib/api/client/services.gen.ts
+++ b/frontend/src/lib/api/client/services.gen.ts
@@ -334,6 +334,7 @@ export const getLectureAccessStatusTicketLectureLectureIdGet = (data: GetLecture
         lecture_id: data.lectureId
     },
     errors: {
+        401: 'Missing token or inactive user.',
         422: 'Validation Error'
     }
 }); };
@@ -352,6 +353,7 @@ export const useTicketTicketLectureLectureIdPost = (data: UseTicketTicketLecture
         lecture_id: data.lectureId
     },
     errors: {
+        401: 'Missing token or inactive user.',
         422: 'Validation Error'
     }
 }); };

--- a/frontend/src/lib/api/client/types.gen.ts
+++ b/frontend/src/lib/api/client/types.gen.ts
@@ -641,6 +641,10 @@ export type $OpenApiTs = {
                  */
                 200: LectureAccessStatus;
                 /**
+                 * Missing token or inactive user.
+                 */
+                401: unknown;
+                /**
                  * Validation Error
                  */
                 422: HTTPValidationError;
@@ -653,6 +657,10 @@ export type $OpenApiTs = {
                  * Successful Response
                  */
                 200: LectureAccessStatus;
+                /**
+                 * Missing token or inactive user.
+                 */
+                401: unknown;
                 /**
                  * Validation Error
                  */


### PR DESCRIPTION
## 배경

모노레포(`frontend`+`backend`)에서 QA/E2E 테스트 구동이 번거롭다는 문제를 개선한다.
방향: **E2E 는 프론트엔드에 두고 백엔드는 mock**, 그리고 그 mock 이 실제 계약과
어긋나지 않도록 OpenAPI 계약을 스냅샷으로 고정한다.

## 변경 사항

### 1. OpenAPI 계약 스냅샷 (drift 차단)
- `backend/dev-scripts/export_openapi.py` — `app.openapi()` 를 DB/네트워크 없이
  `backend/openapi.json` 으로 export. `--check` 로 코드↔스냅샷 동기화 검증
- `frontend/openapi-ts.config.ts` — client 생성 input 을 라이브 URL →
  `../backend/openapi.json` 으로 변경 (백엔드 의존 제거, 스펙 버전 git 고정)
- CI 가드: 백엔드는 코드↔스냅샷, 프론트는 스냅샷↔client 동기화를 diff 로 검증.
  스냅샷 변경 시 프론트 CI 도 트리거되도록 path 추가
- 🔍 도입 즉시 발견된 실제 drift 반영: ticket 엔드포인트 2곳에 백엔드가 추가한
  `401` 응답이 client 에 누락돼 있었음

### 2. 모노레포 통합 러너
- `Makefile` — 루트에서 `make test` / `test-be` / `test-e2e` / `test-unit` /
  `export-spec` / `gen-client` / `check-spec` 등 실행 (소스 통합이 아니라 실행
  진입점만 모음)

### 3. 테스트 전략 문서
- `docs/testing.md` — 계층 책임(백엔드=계약 진실 소스 / 프론트 유닛 /
  프론트 E2E=백엔드 mock)과 계약 스냅샷으로 mock 정확성을 지키는 법
- `docs/domain/build-test.md` — client 재생성이 더는 라이브 백엔드를 요구하지
  않음을 반영, CI/워크플로우 갱신
- `README.md` — 모노레포 Quick start

## 계약 변경 워크플로우
```bash
make gen-client   # 스냅샷 + client 재생성
make check-spec   # drift 검증 (CI 와 동일)
# backend/openapi.json + frontend/src/lib/api/client 를 함께 커밋
```

## 검증
- export 결정성: 재생성해도 `--check` 통과, client diff 항상 동일
- `make check-spec` EXIT=0, `make -n test` 전개 정상
- client 변경은 타입 안전 (api/client 관련 타입 에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 루트 디렉토리에서 실행 가능한 통합 Make 커맨드(install, test, gen-client, check-spec 등) 추가
  * OpenAPI 스펙 스냅샷 기반 API 클라이언트 일관성 자동 검증

* **Documentation**
  * 모노레포 구조 및 개발 워크플로우 문서화
  * 테스트 계층별 책임과 API 클라이언트 생성 프로세스 상세 안내

<!-- end of auto-generated comment: release notes by coderabbit.ai -->