### PR TITLE
🐛 홈 추천/렉처 섹션 모바일 반응형 대응

### DIFF
--- a/frontend/src/lib/components/layout/HeroSection.svelte
+++ b/frontend/src/lib/components/layout/HeroSection.svelte
@@ -9,23 +9,23 @@
 		></div>
 		<!-- Left fade overlay -->
 		<div
-			class="absolute inset-y-0 left-0 w-[200px] bg-gradient-to-r from-[#0c0c0c] to-transparent pointer-events-none"
+			class="absolute inset-y-0 left-0 w-[60px] xl:w-[200px] bg-gradient-to-r from-[#0c0c0c] to-transparent pointer-events-none"
 		></div>
 		<!-- Right fade overlay -->
 		<div
-			class="absolute inset-y-0 right-0 w-[200px] bg-gradient-to-l from-[#0c0c0c] to-transparent pointer-events-none"
+			class="absolute inset-y-0 right-0 w-[60px] xl:w-[200px] bg-gradient-to-l from-[#0c0c0c] to-transparent pointer-events-none"
 		></div>
 		<div
 			class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center z-10 px-4"
 		>
 			<p
-				class="text-[53px] font-pretendard font-bold leading-[67px] tracking-[-0.1em] text-[#F5F5F5] whitespace-nowrap"
+				class="text-[28px] leading-[40px] md:text-[40px] md:leading-[54px] xl:text-[53px] xl:leading-[67px] font-pretendard font-bold tracking-[-0.1em] text-[#F5F5F5] whitespace-nowrap"
 			>
 				찬양으로 하나 되는 순간,<br />
 				연습이 만듭니다
 			</p>
 			<p
-				class="mt-[80px] text-[21px] font-pretendard font-bold leading-[32px] tracking-[-0.02em] text-[#DDDDDD] whitespace-nowrap"
+				class="mt-[40px] xl:mt-[80px] text-[14px] leading-[22px] md:text-[18px] md:leading-[28px] xl:text-[21px] xl:leading-[32px] font-pretendard font-bold tracking-[-0.02em] text-[#DDDDDD] whitespace-nowrap"
 			>
 				인도자의 "기타 SOLO~!" 외침이 두렵지 않을 때까지...
 			</p>

--- a/frontend/src/lib/features/lecture/components/LectureCard.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureCard.svelte
@@ -23,7 +23,7 @@
 
 <a
 	href="/lecture/{lecture.id}"
-	class="group relative w-[296px] h-[239px] bg-black rounded-[6px] overflow-hidden block"
+	class="group relative w-full h-[239px] bg-black rounded-[6px] overflow-hidden block"
 >
 	<div class="relative w-full h-[70.38%] bg-gray-800">
 		<img

--- a/frontend/src/lib/features/lecture/components/LectureList.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureList.svelte
@@ -6,9 +6,9 @@
 </script>
 
 <section
-	class="h-screen snap-start snap-always flex flex-col justify-center xl:items-center bg-black"
+	class="min-h-screen snap-start flex flex-col justify-center xl:items-center bg-black"
 >
-<div class="flex min-h-0 flex-col w-full max-w-[1200px] px-[20px] py-[8vh] xl:px-0">
+<div class="w-full max-w-[1200px] px-[20px] py-[8vh] xl:px-0">
 	<div
 		class="inline-flex items-center gap-[8px] mb-[32px]"
 	>
@@ -22,7 +22,7 @@
 		></div>
 	</div>
 	<div
-		class="grid min-h-0 grid-cols-2 gap-[12px] md:grid-cols-3 xl:grid-cols-4 xl:gap-[24px] overflow-y-auto"
+		class="grid grid-cols-2 gap-[12px] md:grid-cols-3 xl:grid-cols-4 xl:gap-[24px]"
 	>
 		{#each lectures as lecture}
 			<LectureCard {lecture} />

--- a/frontend/src/lib/features/lecture/components/LectureList.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureList.svelte
@@ -6,14 +6,14 @@
 </script>
 
 <section
-	class="h-screen snap-start snap-always flex flex-col justify-center min-[1280px]:items-center min-w-[1280px] bg-black"
+	class="h-screen snap-start snap-always flex flex-col justify-center min-[1280px]:items-center bg-black"
 >
-<div class="w-[1200px] ml-[40px] min-[1280px]:ml-0">
+<div class="w-full max-w-[1200px] px-[20px] min-[1280px]:px-0">
 	<div
 		class="inline-flex items-center gap-[8px] mb-[32px]"
 	>
 		<h2
-			class="text-[36px] font-pretendard font-extrabold leading-[62px] tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
+			class="text-[24px] leading-[36px] min-[1280px]:text-[36px] min-[1280px]:leading-[62px] font-pretendard font-extrabold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
 		>
 			{title}
 		</h2>
@@ -22,7 +22,7 @@
 		></div>
 	</div>
 	<div
-		class="grid grid-cols-4 gap-[24px] overflow-y-auto"
+		class="grid grid-cols-2 gap-[12px] md:grid-cols-3 min-[1280px]:grid-cols-4 min-[1280px]:gap-[24px] overflow-y-auto"
 	>
 		{#each lectures as lecture}
 			<LectureCard {lecture} />

--- a/frontend/src/lib/features/lecture/components/LectureList.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureList.svelte
@@ -6,14 +6,14 @@
 </script>
 
 <section
-	class="h-screen snap-start snap-always flex flex-col justify-center min-[1280px]:items-center bg-black"
+	class="h-screen snap-start snap-always flex flex-col justify-center xl:items-center bg-black"
 >
-<div class="w-full max-w-[1200px] px-[20px] min-[1280px]:px-0">
+<div class="w-full max-w-[1200px] px-[20px] xl:px-0">
 	<div
 		class="inline-flex items-center gap-[8px] mb-[32px]"
 	>
 		<h2
-			class="text-[24px] leading-[36px] min-[1280px]:text-[36px] min-[1280px]:leading-[62px] font-pretendard font-extrabold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
+			class="text-[24px] leading-[36px] xl:text-[36px] xl:leading-[62px] font-pretendard font-extrabold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
 		>
 			{title}
 		</h2>
@@ -22,7 +22,7 @@
 		></div>
 	</div>
 	<div
-		class="grid grid-cols-2 gap-[12px] md:grid-cols-3 min-[1280px]:grid-cols-4 min-[1280px]:gap-[24px] overflow-y-auto"
+		class="grid grid-cols-2 gap-[12px] md:grid-cols-3 xl:grid-cols-4 xl:gap-[24px] overflow-y-auto"
 	>
 		{#each lectures as lecture}
 			<LectureCard {lecture} />

--- a/frontend/src/lib/features/lecture/components/LectureList.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureList.svelte
@@ -8,7 +8,7 @@
 <section
 	class="h-screen snap-start snap-always flex flex-col justify-center xl:items-center bg-black"
 >
-<div class="w-full max-w-[1200px] px-[20px] xl:px-0">
+<div class="flex min-h-0 flex-col w-full max-w-[1200px] px-[20px] py-[8vh] xl:px-0">
 	<div
 		class="inline-flex items-center gap-[8px] mb-[32px]"
 	>
@@ -22,7 +22,7 @@
 		></div>
 	</div>
 	<div
-		class="grid grid-cols-2 gap-[12px] md:grid-cols-3 xl:grid-cols-4 xl:gap-[24px] overflow-y-auto"
+		class="grid min-h-0 grid-cols-2 gap-[12px] md:grid-cols-3 xl:grid-cols-4 xl:gap-[24px] overflow-y-auto"
 	>
 		{#each lectures as lecture}
 			<LectureCard {lecture} />

--- a/frontend/src/lib/features/lecture/components/RecommendCard.svelte
+++ b/frontend/src/lib/features/lecture/components/RecommendCard.svelte
@@ -22,7 +22,7 @@
 		<button
 			type="button"
 			aria-label="강의 재생"
-			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[56px] h-[56px] min-[1280px]:w-[118px] min-[1280px]:h-[118px] cursor-pointer hover:scale-110 transition-transform"
+			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[56px] h-[56px] xl:w-[118px] xl:h-[118px] cursor-pointer hover:scale-110 transition-transform"
 		>
 			<svg
 				class="w-full h-full text-white"
@@ -35,23 +35,23 @@
 			</svg>
 		</button>
 		<div
-			class="absolute top-[16px] right-[16px] min-[1280px]:top-[56px] min-[1280px]:right-[110px] bg-[#FF5C16] px-[12px] py-[4px] min-[1280px]:px-[19px] min-[1280px]:py-[8px] rounded-full flex items-center justify-center"
+			class="absolute top-[16px] right-[16px] xl:top-[56px] xl:right-[110px] bg-[#FF5C16] px-[12px] py-[4px] xl:px-[19px] xl:py-[8px] rounded-full flex items-center justify-center"
 		>
 			<span
-				class="text-[13px] leading-[20px] min-[1280px]:text-[18px] min-[1280px]:leading-[27px] font-pretendard font-bold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
+				class="text-[13px] leading-[20px] xl:text-[18px] xl:leading-[27px] font-pretendard font-bold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
 			>
 				TOP {index + 1}
 			</span>
 		</div>
 	</div>
-	<div class="mt-[20px] min-[1280px]:mt-[38px] text-center w-full px-[16px] min-[1280px]:px-[32px]">
+	<div class="mt-[20px] xl:mt-[38px] text-center w-full px-[16px] xl:px-[32px]">
 		<div
-			class="text-[20px] leading-[30px] min-[1280px]:text-[32px] min-[1280px]:leading-[46px] font-pretendard font-bold tracking-[-0.02em] text-[#F5F5F5] mb-[8px] min-[1280px]:mb-[14px] break-words"
+			class="text-[20px] leading-[30px] xl:text-[32px] xl:leading-[46px] font-pretendard font-bold tracking-[-0.02em] text-[#F5F5F5] mb-[8px] xl:mb-[14px] break-words"
 		>
 			<span class="text-[#FF5C16]">언제 끝날지 모르는 기도회를 위한 무한반복</span>🔥
 		</div>
 		<div
-			class="text-[15px] leading-[24px] min-[1280px]:text-[21px] min-[1280px]:leading-[32px] font-pretendard font-bold tracking-[-0.02em] text-[#DDDDDD] break-words"
+			class="text-[15px] leading-[24px] xl:text-[21px] xl:leading-[32px] font-pretendard font-bold tracking-[-0.02em] text-[#DDDDDD] break-words"
 		>
 			{lecture.title || '[위러브Ver] 우리가 주를 더욱 사랑하고 Easy 버전'}
 		</div>

--- a/frontend/src/lib/features/lecture/components/RecommendCard.svelte
+++ b/frontend/src/lib/features/lecture/components/RecommendCard.svelte
@@ -22,7 +22,7 @@
 		<button
 			type="button"
 			aria-label="강의 재생"
-			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[118px] h-[118px] cursor-pointer hover:scale-110 transition-transform"
+			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[56px] h-[56px] min-[1280px]:w-[118px] min-[1280px]:h-[118px] cursor-pointer hover:scale-110 transition-transform"
 		>
 			<svg
 				class="w-full h-full text-white"
@@ -35,23 +35,23 @@
 			</svg>
 		</button>
 		<div
-			class="absolute top-[56px] right-[110px] bg-[#FF5C16] px-[19px] py-[8px] rounded-full flex items-center justify-center"
+			class="absolute top-[16px] right-[16px] min-[1280px]:top-[56px] min-[1280px]:right-[110px] bg-[#FF5C16] px-[12px] py-[4px] min-[1280px]:px-[19px] min-[1280px]:py-[8px] rounded-full flex items-center justify-center"
 		>
 			<span
-				class="text-[18px] font-pretendard font-bold leading-[27px] tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
+				class="text-[13px] leading-[20px] min-[1280px]:text-[18px] min-[1280px]:leading-[27px] font-pretendard font-bold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
 			>
 				TOP {index + 1}
 			</span>
 		</div>
 	</div>
-	<div class="mt-[38px] text-center w-full px-[32px]">
+	<div class="mt-[20px] min-[1280px]:mt-[38px] text-center w-full px-[16px] min-[1280px]:px-[32px]">
 		<div
-			class="text-[32px] font-pretendard font-bold leading-[46px] tracking-[-0.02em] text-[#F5F5F5] mb-[14px] break-words"
+			class="text-[20px] leading-[30px] min-[1280px]:text-[32px] min-[1280px]:leading-[46px] font-pretendard font-bold tracking-[-0.02em] text-[#F5F5F5] mb-[8px] min-[1280px]:mb-[14px] break-words"
 		>
 			<span class="text-[#FF5C16]">언제 끝날지 모르는 기도회를 위한 무한반복</span>🔥
 		</div>
 		<div
-			class="text-[21px] font-pretendard font-bold leading-[32px] tracking-[-0.02em] text-[#DDDDDD] break-words"
+			class="text-[15px] leading-[24px] min-[1280px]:text-[21px] min-[1280px]:leading-[32px] font-pretendard font-bold tracking-[-0.02em] text-[#DDDDDD] break-words"
 		>
 			{lecture.title || '[위러브Ver] 우리가 주를 더욱 사랑하고 Easy 버전'}
 		</div>

--- a/frontend/src/lib/features/lecture/components/RecommendCarousel.svelte
+++ b/frontend/src/lib/features/lecture/components/RecommendCarousel.svelte
@@ -55,11 +55,11 @@
 				type="button"
 				onclick={goToPrevious}
 				disabled={!canGoPrevious}
-				class="absolute left-[32px] top-1/2 -translate-y-1/2 w-[64px] h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
+				class="absolute left-[8px] min-[1280px]:left-[32px] top-1/2 -translate-y-1/2 w-[40px] h-[40px] min-[1280px]:w-[64px] min-[1280px]:h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
 				aria-label="이전 슬라이드"
 			>
 				<svg
-					class="w-[32px] h-[32px]"
+					class="w-[20px] h-[20px] min-[1280px]:w-[32px] min-[1280px]:h-[32px]"
 					fill="none"
 					stroke="currentColor"
 					viewBox="0 0 24 24"
@@ -78,11 +78,11 @@
 				type="button"
 				onclick={goToNext}
 				disabled={!canGoNext}
-				class="absolute right-[32px] top-1/2 -translate-y-1/2 w-[64px] h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
+				class="absolute right-[8px] min-[1280px]:right-[32px] top-1/2 -translate-y-1/2 w-[40px] h-[40px] min-[1280px]:w-[64px] min-[1280px]:h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
 				aria-label="다음 슬라이드"
 			>
 				<svg
-					class="w-[32px] h-[32px]"
+					class="w-[20px] h-[20px] min-[1280px]:w-[32px] min-[1280px]:h-[32px]"
 					fill="none"
 					stroke="currentColor"
 					viewBox="0 0 24 24"

--- a/frontend/src/lib/features/lecture/components/RecommendCarousel.svelte
+++ b/frontend/src/lib/features/lecture/components/RecommendCarousel.svelte
@@ -55,11 +55,11 @@
 				type="button"
 				onclick={goToPrevious}
 				disabled={!canGoPrevious}
-				class="absolute left-[8px] min-[1280px]:left-[32px] top-1/2 -translate-y-1/2 w-[40px] h-[40px] min-[1280px]:w-[64px] min-[1280px]:h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
+				class="absolute left-[8px] xl:left-[32px] top-1/2 -translate-y-1/2 w-[40px] h-[40px] xl:w-[64px] xl:h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
 				aria-label="이전 슬라이드"
 			>
 				<svg
-					class="w-[20px] h-[20px] min-[1280px]:w-[32px] min-[1280px]:h-[32px]"
+					class="w-[20px] h-[20px] xl:w-[32px] xl:h-[32px]"
 					fill="none"
 					stroke="currentColor"
 					viewBox="0 0 24 24"
@@ -78,11 +78,11 @@
 				type="button"
 				onclick={goToNext}
 				disabled={!canGoNext}
-				class="absolute right-[8px] min-[1280px]:right-[32px] top-1/2 -translate-y-1/2 w-[40px] h-[40px] min-[1280px]:w-[64px] min-[1280px]:h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
+				class="absolute right-[8px] xl:right-[32px] top-1/2 -translate-y-1/2 w-[40px] h-[40px] xl:w-[64px] xl:h-[64px] bg-[#0C0C0C] bg-opacity-60 hover:bg-opacity-80 rounded-full flex items-center justify-center text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed pointer-events-auto"
 				aria-label="다음 슬라이드"
 			>
 				<svg
-					class="w-[20px] h-[20px] min-[1280px]:w-[32px] min-[1280px]:h-[32px]"
+					class="w-[20px] h-[20px] xl:w-[32px] xl:h-[32px]"
 					fill="none"
 					stroke="currentColor"
 					viewBox="0 0 24 24"

--- a/frontend/src/lib/features/lecture/components/RecommendSection.svelte
+++ b/frontend/src/lib/features/lecture/components/RecommendSection.svelte
@@ -6,11 +6,11 @@
 </script>
 
 <section
-	class="h-screen snap-start snap-always flex flex-col min-[1280px]:items-center py-[15vh] min-w-[1280px] bg-black"
+	class="h-screen snap-start snap-always flex flex-col min-[1280px]:items-center py-[10vh] min-[1280px]:py-[15vh] bg-black"
 >
-<div class="w-[1200px] ml-[40px] min-[1280px]:ml-0">
+<div class="w-full max-w-[1200px] px-[20px] min-[1280px]:px-0">
 	<h2
-		class="mb-[64px] flex items-center text-[37px] font-pretendard font-extrabold leading-[62px] tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
+		class="mb-[32px] min-[1280px]:mb-[64px] flex items-center text-[24px] leading-[36px] min-[1280px]:text-[37px] min-[1280px]:leading-[62px] font-pretendard font-extrabold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
 	>
 		<span>요즘 많이 보는 렉처</span>
 		<span class="text-[#FF5C16] ml-[12px]">TOP 5</span>

--- a/frontend/src/lib/features/lecture/components/RecommendSection.svelte
+++ b/frontend/src/lib/features/lecture/components/RecommendSection.svelte
@@ -6,11 +6,11 @@
 </script>
 
 <section
-	class="h-screen snap-start snap-always flex flex-col min-[1280px]:items-center py-[10vh] min-[1280px]:py-[15vh] bg-black"
+	class="h-screen snap-start snap-always flex flex-col xl:items-center py-[10vh] xl:py-[15vh] bg-black"
 >
-<div class="w-full max-w-[1200px] px-[20px] min-[1280px]:px-0">
+<div class="w-full max-w-[1200px] px-[20px] xl:px-0">
 	<h2
-		class="mb-[32px] min-[1280px]:mb-[64px] flex items-center text-[24px] leading-[36px] min-[1280px]:text-[37px] min-[1280px]:leading-[62px] font-pretendard font-extrabold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
+		class="mb-[32px] xl:mb-[64px] flex items-center text-[24px] leading-[36px] xl:text-[37px] xl:leading-[62px] font-pretendard font-extrabold tracking-[-0.02em] text-[#F5F5F5] whitespace-nowrap"
 	>
 		<span>요즘 많이 보는 렉처</span>
 		<span class="text-[#FF5C16] ml-[12px]">TOP 5</span>


### PR DESCRIPTION
## 문제

홈 페이지 모바일 대응이 NavBar만 되어 있고, 나머지 섹션들은 고정 폭/고정 폰트라 모바일에서 반응하지 않음.

## 변경 사항

| 컴포넌트 | 변경 |
|---|---|
| `HeroSection` | 메인 문구 28px(모바일)/40px(md)/53px(xl), 좌우 페이드 200px→60px(모바일) |
| `RecommendSection` | `min-w-[1280px]` 제거, `w-[1200px] ml-[40px]` → `w-full max-w-[1200px] px-[20px]`, 제목 24px(모바일)/37px(xl) |
| `LectureList` | 동일한 컨테이너 처리, 그리드 `grid-cols-2 → md:grid-cols-3 → xl:grid-cols-4` |
| `LectureCard` | 고정 폭 `w-[296px]` → `w-full` (그리드 셀에 맞춤) |
| `RecommendCard` | 제목/부제목 폰트, TOP 배지 위치·크기, 재생 버튼 크기 모바일 축소 |
| `RecommendCarousel` | 좌우 화살표 버튼 64px → 40px(모바일), 위치 조정 |

### 주의: `min-[1280px]:` → `xl:` 교체 이유

Tailwind가 임의 variant `min-[1280px]:`를 `md:`보다 **앞 순서**로 CSS에 생성해, 1280px 이상에서 `md:grid-cols-3`이 `min-[1280px]:grid-cols-4`를 덮어쓰는 버그가 실측에서 확인됨. 기본 브레이크포인트 `xl:`(동일한 1280px)은 정렬이 보장되어 교체.

## 검증

- `svelte-check` 0 errors, `vite build` 성공, 단위 테스트 105개 통과
- 로컬 dev 스택에서 Playwright로 실측:

| 뷰포트 | 그리드 | 히어로 폰트 | 가로 오버플로 |
|---|---|---|---|
| 390px | 2열 | 28px | 없음 |
| 768px | 3열 | 40px | 없음 |
| 1280px | 4열 | 53px | 없음 |
| 1440px | 4열 | 53px | 없음 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)