### PR TITLE
🐛 iOS Safari 동영상 무한 로딩 스피너 데드락 수정

### DIFF
--- a/frontend/src/lib/features/session/components/VideoPlayer.svelte
+++ b/frontend/src/lib/features/session/components/VideoPlayer.svelte
@@ -37,6 +37,22 @@
 		}
 		return src
 	}
+
+	/**
+	 * 로딩 스피너 해제 여부 판단
+	 * iOS Safari는 사용자 제스처 전까지 canplay를 발생시키지 않으므로
+	 * loadedmetadata 시점에도 로딩을 해제한다
+	 */
+	export function shouldClearLoading(eventType: 'canplay' | 'loadedmetadata'): boolean {
+		return eventType === 'canplay' || eventType === 'loadedmetadata'
+	}
+
+	/**
+	 * 스피너 오버레이 클래스
+	 * pointer-events-none: 스피너가 떠 있어도 아래 VideoControls 탭이 가능해야 함 (iOS 데드락 방지)
+	 */
+	export const SPINNER_OVERLAY_CLASS =
+		'absolute inset-0 flex items-center justify-center bg-black/50 z-10 pointer-events-none'
 </script>
 
 <script lang="ts">
@@ -104,8 +120,16 @@
 	}
 
 	function handleCanPlay() {
-		isLoading = false
-		errorMessage = null
+		if (shouldClearLoading('canplay')) {
+			isLoading = false
+			errorMessage = null
+		}
+	}
+
+	function handleLoadedMetadata() {
+		if (shouldClearLoading('loadedmetadata')) {
+			isLoading = false
+		}
 	}
 
 	function initHls() {
@@ -165,7 +189,7 @@
 
 <div data-testid="video-player" class="relative w-full aspect-video bg-black rounded-xl overflow-hidden">
 	{#if isLoading}
-		<div class="absolute inset-0 flex items-center justify-center bg-black/50 z-10">
+		<div class={SPINNER_OVERLAY_CLASS}>
 			<div class="w-12 h-12 border-4 border-white/30 border-t-white rounded-full animate-spin">
 			</div>
 		</div>
@@ -186,11 +210,13 @@
 		{poster}
 		src={getVideoSource(src, nativeHlsSupport)}
 		playsinline
+		preload="metadata"
 		ontimeupdate={handleTimeUpdate}
 		onplay={handlePlay}
 		onpause={handlePause}
 		onended={handleEnded}
 		oncanplay={handleCanPlay}
+		onloadedmetadata={handleLoadedMetadata}
 		onerror={() => handleError('Failed to load video')}
 	>
 		<track kind="captions" />

--- a/frontend/src/lib/features/session/components/VideoPlayer.svelte
+++ b/frontend/src/lib/features/session/components/VideoPlayer.svelte
@@ -129,6 +129,7 @@
 	function handleLoadedMetadata() {
 		if (shouldClearLoading('loadedmetadata')) {
 			isLoading = false
+			errorMessage = null
 		}
 	}
 

--- a/frontend/tests/unit/features/session/VideoPlayer.test.ts
+++ b/frontend/tests/unit/features/session/VideoPlayer.test.ts
@@ -72,4 +72,37 @@ describe('VideoPlayer', () => {
 			expect(src).toBe('')
 		})
 	})
+
+	describe('shouldClearLoading', () => {
+		it('canplay 이벤트 시 로딩을 해제한다', async () => {
+			const { shouldClearLoading } = await import(
+				'$lib/features/session/components/VideoPlayer.svelte'
+			)
+			expect(shouldClearLoading('canplay')).toBe(true)
+		})
+
+		it('loadedmetadata 이벤트 시에도 로딩을 해제한다 (iOS Safari 대응)', async () => {
+			const { shouldClearLoading } = await import(
+				'$lib/features/session/components/VideoPlayer.svelte'
+			)
+			expect(shouldClearLoading('loadedmetadata')).toBe(true)
+		})
+	})
+
+	describe('SPINNER_OVERLAY_CLASS', () => {
+		it('pointer-events-none을 포함해 아래 컨트롤 탭을 막지 않는다', async () => {
+			const { SPINNER_OVERLAY_CLASS } = await import(
+				'$lib/features/session/components/VideoPlayer.svelte'
+			)
+			expect(SPINNER_OVERLAY_CLASS).toContain('pointer-events-none')
+		})
+
+		it('기존 오버레이 레이아웃 클래스를 유지한다', async () => {
+			const { SPINNER_OVERLAY_CLASS } = await import(
+				'$lib/features/session/components/VideoPlayer.svelte'
+			)
+			expect(SPINNER_OVERLAY_CLASS).toContain('absolute inset-0')
+			expect(SPINNER_OVERLAY_CLASS).toContain('z-10')
+		})
+	})
 })


### PR DESCRIPTION
## Summary
아이폰 Safari에서 lesson 동영상이 무한 로딩 스피너에 갇혀 재생이 불가능한 버그를 수정한다.

**원인 (데드락):**
1. `isLoading`은 `canplay` 이벤트에서만 해제되는데, iOS Safari는 사용자 제스처 전까지 비디오 데이터를 프리로드하지 않아 `canplay`가 발생하지 않음
2. 로딩 스피너 오버레이(`z-10`, `pointer-events` 가로챔)가 VideoControls의 재생 버튼 탭을 차단
3. 재생 버튼을 못 누름 → `canplay` 안 옴 → 스피너 영원히 유지

## Changes
- `VideoPlayer.svelte`
  - 스피너 오버레이에 `pointer-events-none` 추가 — 스피너가 떠 있어도 컨트롤 탭 가능
  - `loadedmetadata` 이벤트에서도 로딩 해제 (`shouldClearLoading` 헬퍼 추가)
  - `preload="metadata"` 명시
- `VideoPlayer.test.ts` — `shouldClearLoading`, `SPINNER_OVERLAY_CLASS` 테스트 추가

## Test plan
- [x] 유닛 테스트 109개 전체 통과 (`yarn vitest run`)
- [x] svelte-check 0 errors
- [ ] 실기기(iPhone Safari) staging에서 재생 확인

---
🚀 Created via `/quick-pr`
🤖 Generated with [Claude Code](https://claude.com/claude-code)