### PR TITLE
🐛 렉처 진행도 패널: 티켓 사용 여부에 따른 활성/inactive 분기

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,20 @@ APP_ENV ?= dev
 # 컨테이너 네트워크 호스트명(auth-redis)이라 호스트에서는 DNS 해석이 안 되므로 덮어쓴다.
 # (DATABASE_URL 은 .env.dev 가 이미 localhost 라 그대로 쓴다.)
 AUTH_REDIS_URL ?= redis://localhost:6379
+# 호스트 frontend dev 포트. 다른 로컬 프로젝트와의 충돌을 피하려 3000 대신 3100 을 기본값으로 쓴다.
+# (compose 경로는 여전히 3000:5173 매핑을 쓰므로 .env.dev 의 OAuth redirect 기본값은 3000 으로 둔다.)
+FE_PORT ?= 3100
+# 호스트 직접 실행 시 OAuth redirect_uri 를 실제 fe 포트로 맞춘다. .env.dev 값(compose 기본 3000)을 덮어쓴다.
+# 주의: 이 redirect_uri 가 Google Cloud Console 의 승인된 리디렉션 URI 에 등록돼 있어야 로그인이 동작한다.
+GOOGLE_OAUTH_REDIRECT_URI ?= http://localhost:$(FE_PORT)/oauth-callback
 # devup 의 backend 명령에 공통으로 붙는 호스트-실행용 환경
-DEV_BE_ENV := APP_ENV=$(APP_ENV) AUTH_REDIS_URL=$(AUTH_REDIS_URL)
+DEV_BE_ENV := APP_ENV=$(APP_ENV) AUTH_REDIS_URL=$(AUTH_REDIS_URL) GOOGLE_OAUTH_REDIRECT_URI=$(GOOGLE_OAUTH_REDIRECT_URI)
 
 help: ## 사용 가능한 명령 목록
 	@echo "Sessionary 통합 명령:"
 	@echo "  make install      - fe/be 의존성 설치"
-	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:3000) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
-	@echo "  make devdown      - 호스트 dev 앱(:8000,:3000) 종료 (인프라는 유지)"
+	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:$(FE_PORT)) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
+	@echo "  make devdown      - 호스트 dev 앱(:8000,:$(FE_PORT)) 종료 (인프라는 유지)"
 	@echo "  make infra-up     - 공유 로컬 인프라(db/redis/minio)만 기동"
 	@echo "  make infra-down   - 공유 인프라 중지 (볼륨 데이터 보존)"
 	@echo "  make test         - 백엔드 + 프론트엔드 전체 테스트"
@@ -52,9 +58,10 @@ install: ## fe/be 의존성 설치
 #
 # 전략: "단일 활성 + 공유 인프라".
 #  - 인프라(db/redis/minio)는 stateful & worktree 공용 → 한 벌만 띄워 공유.
-#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:3000) → 활성 worktree 하나에서만.
-#    fe 는 3000: Google OAuth redirect_uri 가 localhost:3000/oauth-callback 기준이라
-#    vite 기본값(5173) 대신 3000 으로 강제(--strictPort)해 콜백을 일치시킨다.
+#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:$(FE_PORT)) → 활성 worktree 하나에서만.
+#    fe 는 FE_PORT(기본 3100)로 강제(--strictPort)하고, devup 이 OAuth redirect_uri 를
+#    그 포트로 주입(GOOGLE_OAUTH_REDIRECT_URI)해 콜백을 일치시킨다. vite 기본값(5173)은 안 쓴다.
+#    포트를 바꾸려면 `make devup FE_PORT=3000` 처럼 오버라이드한다.
 # worktree 전환: 현재에서 Ctrl-C(또는 make devdown) → 다른 worktree 에서 make devup.
 # 인프라는 재사용되고 앱만 새로 뜬다.
 
@@ -66,15 +73,15 @@ infra-down: ## 공유 인프라 중지 (볼륨 데이터는 보존)
 
 devup: infra-up ## 공유 인프라 + be/fe 개발 서버 동시 구동 (Ctrl-C 로 둘 다 종료)
 	cd backend && $(DEV_BE_ENV) uv run alembic upgrade head
-	@echo "▶ backend(:8000) + frontend(:3000) 기동 — Ctrl-C 로 둘 다 종료"
+	@echo "▶ backend(:8000) + frontend(:$(FE_PORT)) 기동 — Ctrl-C 로 둘 다 종료"
 	@trap 'kill 0' INT TERM EXIT; \
 	(cd backend && $(DEV_BE_ENV) uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
-	(cd frontend && yarn dev --port 3000 --strictPort) & \
+	(cd frontend && VITE_HMR_CLIENT_PORT=$(FE_PORT) yarn dev --port $(FE_PORT) --strictPort) & \
 	wait
 
-devdown: ## 호스트 dev 앱(:8000,:3000) 종료 — 인프라는 유지
+devdown: ## 호스트 dev 앱(:8000,:$(FE_PORT)) 종료 — 인프라는 유지
 	-@pids=$$(lsof -ti tcp:8000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
-	-@pids=$$(lsof -ti tcp:3000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
+	-@pids=$$(lsof -ti tcp:$(FE_PORT)); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
 	@echo "dev 앱 종료. 인프라까지 내리려면 make infra-down."
 
 # --- 테스트 -----------------------------------------------------------------

--- a/docs/domain/build-test.md
+++ b/docs/domain/build-test.md
@@ -108,15 +108,19 @@ bash infra/scripts/setup-staging-secrets.sh
 
 ### 빠른 시작 (권장): `make devup`
 ```bash
-make devup    # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:3000) 동시 구동
-              # Ctrl-C 로 be/fe 둘 다 종료 (인프라는 유지)
-make devdown  # 호스트 dev 앱(:8000,:3000)만 종료, 인프라는 유지
+make devup            # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:3100) 동시 구동
+                      # Ctrl-C 로 be/fe 둘 다 종료 (인프라는 유지)
+make devup FE_PORT=3000   # 포트 오버라이드 (다른 로컬 프로젝트와 충돌 시 조절)
+make devdown          # 호스트 dev 앱(:8000,:3100)만 종료, 인프라는 유지
 ```
 
 **전략: 단일 활성 + 공유 인프라.** 인프라(db/redis/minio)는 stateful & worktree 공용이라
 `docker compose -p sessionary-dev` 로 한 벌만 띄워 모든 worktree가 공유한다. 앱(be/fe)은
-무상태 & 포트 고정(:8000/:3000)이라 활성 worktree 하나에서만 띄운다.
-fe 는 3000 으로 띄운다 (Google OAuth redirect_uri 가 `localhost:3000/oauth-callback` 기준).
+무상태 & 포트 고정(:8000/:`FE_PORT`)이라 활성 worktree 하나에서만 띄운다.
+fe 는 `FE_PORT`(기본 3100)로 띄우고, devup 이 OAuth redirect_uri 를 그 포트로 주입한다
+(`GOOGLE_OAUTH_REDIRECT_URI=http://localhost:$FE_PORT/oauth-callback`). 기본 3000 대신 3100 을
+쓰는 이유는 다른 로컬 프로젝트(3000 사용)와의 충돌을 피하기 위함. **새 포트는 Google Cloud
+Console 의 승인된 리디렉션 URI 에 `http://localhost:3100/oauth-callback` 가 등록돼 있어야 로그인이 된다.**
 worktree 전환: 현재에서 Ctrl-C → 다른 worktree 에서 `make devup` (인프라 재사용, 앱만 새로).
 여러 worktree 의 앱을 *동시에* 띄우려면 포트가 충돌하므로 단일 활성 모델을 쓴다.
 
@@ -128,7 +132,7 @@ make infra-up   # = docker compose -p sessionary-dev -f infra/dev/docker-compose
 # 또는 수동:
 cd infra/dev && docker compose up -d  # PostgreSQL, Redis, MinIO (+ be/fe 컨테이너까지 전부)
 ```
-> 주의: `infra/dev/docker-compose.yml` 은 backend/frontend 컨테이너(:8000/:3000)도 정의한다.
+> 주의: `infra/dev/docker-compose.yml` 은 backend/frontend 컨테이너(:8000/:3000, 호스트 3000→컨테이너 5173)도 정의한다.
 > 호스트에서 `uv run`/`yarn dev` 로 앱을 띄울 거면 인프라 서비스만 올려야 포트가 안 겹친다
 > (`make infra-up` 이 인프라만 선택해서 띄운다).
 
@@ -145,7 +149,9 @@ APP_ENV=dev uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000
 ```bash
 cd frontend
 yarn install
-yarn dev --port 3000 --strictPort  # http://localhost:3000 (OAuth redirect_uri 가 3000 기준)
+VITE_HMR_CLIENT_PORT=3100 yarn dev --port 3100 --strictPort  # http://localhost:3100
+# 단독 실행 시 backend 에 동일 포트의 redirect_uri 를 줘야 한다:
+#   GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3100/oauth-callback ... uvicorn ...
 ```
 
 ### API 클라이언트 재생성

--- a/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
@@ -7,12 +7,14 @@
 		sessions,
 		progress = null,
 		isAuthenticated = false,
+		accessible = null,
 		onstart,
 		onlogin
 	}: {
 		sessions: LessonInLecture[]
 		progress?: LectureProgress | null
 		isAuthenticated?: boolean
+		accessible?: boolean | null
 		onstart?: (lessonId: number) => void
 		onlogin?: () => void
 	} = $props()
@@ -21,7 +23,7 @@
 		[...sessions].sort((a, b) => a.lecture_ordering - b.lecture_ordering)
 	)
 
-	let mode = $derived(getLectureStatusMode(progress, isAuthenticated))
+	let mode = $derived(getLectureStatusMode(progress, isAuthenticated, accessible))
 	let cells = $derived(buildMinimap(sortedSessions, progress, isAuthenticated))
 
 	let resumeLessonId = $derived(getResumeLessonId(sortedSessions, progress, isAuthenticated))
@@ -94,16 +96,17 @@
 		</div>
 	{:else if mode === 'not-started'}
 		<span
-			class="mb-[18px] self-start rounded-full bg-[rgba(255,92,22,0.12)] px-[11px] py-[4px] text-[12px] font-bold text-[#ff5c16]"
+			data-testid="not-started-badge"
+			class="mb-[18px] self-start rounded-full bg-[#1a1a1a] px-[11px] py-[4px] text-[12px] font-bold text-[#848484]"
 		>
 			미수강
 		</span>
-		<div class="mb-[18px] flex items-center justify-between">
+		<div class="mb-[18px] flex items-center justify-between opacity-50">
 			<span class="text-[15px] font-semibold text-[#c9c9c9]">커리큘럼</span>
 			<span class="text-[13px] text-[#656565]">0 / {totalCount} 세션</span>
 		</div>
-		<div class="min-w-0">
-			<div class="text-[12px] font-bold tracking-wide text-[#ff5c16]">시작하기</div>
+		<div class="min-w-0 opacity-50">
+			<div class="text-[12px] font-bold tracking-wide text-[#848484]">시작하기</div>
 			<div class="mt-[5px] text-[17px] font-bold leading-[1.35] text-white">
 				{resumeNumber}. {resumeLesson?.title ?? ''}
 			</div>
@@ -126,7 +129,7 @@
 	{/if}
 
 	{#if mode !== 'anonymous'}
-		<div class="mt-[18px] grid grid-cols-6 gap-[6px]">
+		<div class="mt-[18px] grid grid-cols-6 gap-[6px]" class:opacity-50={mode === 'not-started'}>
 			{#each cells as cell}
 				<span
 					class="h-[9px] rounded-[3px]"
@@ -134,7 +137,7 @@
 					style={cell === 'done'
 						? 'background:#ff5c16'
 						: cell === 'current'
-							? 'background:transparent;border:1.5px solid #ff5c16'
+							? `background:transparent;border:1.5px solid ${mode === 'not-started' ? '#3a3a3a' : '#ff5c16'}`
 							: 'background:#1a1a1a'}
 				></span>
 			{/each}

--- a/frontend/src/lib/features/lecture/utils/lectureAccess.svelte.ts
+++ b/frontend/src/lib/features/lecture/utils/lectureAccess.svelte.ts
@@ -21,7 +21,20 @@ export function createLectureAccess(lectureId: number) {
 	let showInsufficientModal = $state(false)
 	let ticketCount = $state(0)
 	let daysUntilRefill = $state(0)
+	let accessible = $state<boolean | null>(null)
 	let pendingSessionId: number | null = null
+
+	async function loadAccessStatus() {
+		if (!auth.isAuthenticated) return
+		await waitForApiInit()
+		try {
+			const status = await getLectureAccessStatusTicketLectureLectureIdGet({ lectureId })
+			accessible = status.accessible
+			ticketCount = status.ticket_count
+		} catch {
+			accessible = null
+		}
+	}
 
 	function calculateDaysUntilNextMonday(): number {
 		const now = new Date()
@@ -138,6 +151,10 @@ export function createLectureAccess(lectureId: number) {
 		get daysUntilRefill() {
 			return daysUntilRefill
 		},
+		get accessible() {
+			return accessible
+		},
+		loadAccessStatus,
 		requestSession,
 		resumePendingSessionIfExists,
 		confirmTicket,

--- a/frontend/src/lib/features/lecture/utils/progress.ts
+++ b/frontend/src/lib/features/lecture/utils/progress.ts
@@ -8,10 +8,17 @@ export type SessionState = 'completed' | 'current' | 'upcoming' | 'locked'
 
 export function getLectureStatusMode(
 	progress: LectureProgress | null | undefined,
-	isAuthenticated: boolean
+	isAuthenticated: boolean,
+	accessible?: boolean | null
 ): LectureStatusMode {
 	if (!progress || !isAuthenticated) {
 		return 'anonymous'
+	}
+	if (accessible === true) {
+		return 'in-progress'
+	}
+	if (accessible === false) {
+		return 'not-started'
 	}
 	return progress.completed_count > 0 ? 'in-progress' : 'not-started'
 }

--- a/frontend/src/routes/lecture/[id]/+page.svelte
+++ b/frontend/src/routes/lecture/[id]/+page.svelte
@@ -41,6 +41,9 @@
 		const id = Number($page.params.id)
 		if (!isNaN(id) && id > 0) {
 			access = createLectureAccess(id)
+			if (auth.isAuthenticated) {
+				access.loadAccessStatus()
+			}
 			fetchLecture(id)
 		}
 	})
@@ -78,6 +81,7 @@
 					sessions={lecture.lessons}
 					progress={lecture.progress}
 					isAuthenticated={auth.isAuthenticated}
+					accessible={access?.accessible}
 					onstart={handleSessionClick}
 					onlogin={() => access && (access.showLoginModal = true)}
 				/>

--- a/frontend/src/routes/lecture/[id]/+page.svelte
+++ b/frontend/src/routes/lecture/[id]/+page.svelte
@@ -40,9 +40,10 @@
 	$effect(() => {
 		const id = Number($page.params.id)
 		if (!isNaN(id) && id > 0) {
-			access = createLectureAccess(id)
+			const controller = createLectureAccess(id)
+			access = controller
 			if (auth.isAuthenticated) {
-				access.loadAccessStatus()
+				controller.loadAccessStatus()
 			}
 			fetchLecture(id)
 		}

--- a/frontend/tests/features/lecture/lecture-progress-panel-access.test.ts
+++ b/frontend/tests/features/lecture/lecture-progress-panel-access.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+import {
+	API_BASE_URL,
+	COOKIE_NAME,
+	TEST_TOKEN,
+	mockLectureApi,
+	mockTicketAccessApi,
+	mockUserMeApi
+} from '../../helpers/api-mocks'
+
+test.describe('렉처 진행도 패널 - 접근상태 조회', () => {
+	test('인증 사용자가 렉처에 진입해도 접근상태 API를 무한 호출하지 않는다', async ({
+		page,
+		context
+	}) => {
+		// 로그인 상태 재현: API 도메인에 세션 쿠키 주입 → /user/me 가 200 을 반환
+		await context.addCookies([
+			{ name: COOKIE_NAME, value: TEST_TOKEN, url: API_BASE_URL }
+		])
+
+		mockUserMeApi(page)
+		mockLectureApi(page)
+		mockTicketAccessApi(page, true, 0)
+
+		let ticketCalls = 0
+		page.on('request', (request) => {
+			if (request.url().includes('/ticket/lecture/')) {
+				ticketCalls++
+			}
+		})
+
+		await page.goto('/lecture/1')
+		await page.waitForLoadState('load')
+		await page.locator('[data-testid="lecture-progress-panel"]').waitFor({ timeout: 15000 })
+
+		// 반응성 루프가 있으면 이 대기 동안 수백 회 호출된다
+		await page.waitForTimeout(2000)
+
+		expect(ticketCalls).toBeLessThanOrEqual(1)
+	})
+})

--- a/frontend/tests/unit/features/lecture/progress.test.ts
+++ b/frontend/tests/unit/features/lecture/progress.test.ts
@@ -33,6 +33,32 @@ describe('getLectureStatusMode', () => {
 			'in-progress'
 		)
 	})
+
+	it('accessible=true 이고 completed=0 이면 in-progress (0% 활성)', () => {
+		expect(getLectureStatusMode(progress({ completed_count: 0 }), true, true)).toBe('in-progress')
+	})
+
+	it('accessible=false 이면 completed>0 이어도 not-started (티켓 미사용 우선)', () => {
+		expect(getLectureStatusMode(progress({ completed_count: 2, percent: 66 }), true, false)).toBe(
+			'not-started'
+		)
+	})
+
+	it('accessible=true 이고 completed>0 이면 in-progress', () => {
+		expect(getLectureStatusMode(progress({ completed_count: 1, percent: 33 }), true, true)).toBe(
+			'in-progress'
+		)
+	})
+
+	it('accessible 생략 시 기존 휴리스틱 유지', () => {
+		expect(getLectureStatusMode(progress({ completed_count: 0 }), true)).toBe('not-started')
+		expect(getLectureStatusMode(progress({ completed_count: 1 }), true)).toBe('in-progress')
+	})
+
+	it('비인증이면 accessible 값과 무관하게 anonymous', () => {
+		expect(getLectureStatusMode(progress({ completed_count: 1 }), false, true)).toBe('anonymous')
+		expect(getLectureStatusMode(progress({ completed_count: 1 }), false, false)).toBe('anonymous')
+	})
 })
 
 describe('getSessionState', () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
 		host: '0.0.0.0',
 		port: 5173,
 		hmr: {
-			clientPort: 3000
+			// compose 경로는 3000:5173 매핑이라 기본 3000. 호스트 devup 은 VITE_HMR_CLIENT_PORT 로 실제 fe 포트를 넘긴다.
+			clientPort: Number(process.env.VITE_HMR_CLIENT_PORT) || 3000
 		},
 		watch: {
 			usePolling: true


### PR DESCRIPTION
## 개요
렉처 상세 페이지 Hero 우측 `LectureProgressPanel`이 **티켓 사용 여부(`accessible`)**에 따라 활성/inactive로 분기되도록 수정. (#123)

## 변경 사항
- `getLectureStatusMode`에 `accessible` 인자 추가
  - `accessible=true`(티켓 사용) → `in-progress`(원형 진행도 UI, 0%여도 활성)
  - 로그인 O · `accessible=false`(티켓 미사용) → `not-started`(inactive 톤)
  - `accessible` 미확정 시 기존 `completed_count` 휴리스틱 폴백 (하위호환)
- `createLectureAccess`에 `accessible` reactive state + `loadAccessStatus()` 추가 (인증 사용자만 eager 조회)
- `lecture/[id]/+page.svelte`에서 접근상태 eager 호출 후 패널에 prop 전달
- `not-started` 모드 inactive 톤 적용: 미수강 뱃지·`시작하기` 라벨·그리드 current 셀의 brand(`#ff5c16`) 강조 제거 → 중립 톤 + 커리큘럼/그리드 `opacity-50` dim (CTA 기능 유지)

## 테스트
- `progress.test.ts`에 accessible 분기 케이스 추가 — vitest 13 passed
- `svelte-check` 0 errors

## 미해결 확인 사항
- 계획서의 "확인 필요": `accessible=true` 판정 기준은 백엔드 `LectureAccessStatus.accessible`로 충분(reason: `unlimited`/`ticket_used` 등)함을 확인.

Closes #123