### PR TITLE
🔧 make devup/devdown: 단일 활성 + 공유 인프라 로컬 개발 러너

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,24 @@
 # (소스를 통합하는 것이 아니라 "어디서 무엇을 치는지"만 모은다.)
 
 .PHONY: help install \
+        devup devdown infra-up infra-down \
         test test-be test-fe test-unit test-e2e \
         export-spec gen-client check-spec \
         lint format check
 
+# 로컬 인프라 스택. -p 로 프로젝트명을 고정해 어느 worktree 에서 실행하든
+# 같은 db/redis/minio(=같은 데이터) 한 벌을 가리키게 한다.
+COMPOSE := docker compose -p sessionary-dev -f infra/dev/docker-compose.yml
+# stateful 인프라만 (앱 컨테이너 backend/frontend 는 호스트에서 직접 띄운다)
+INFRA_SERVICES := db auth-redis minio minio-init
+
 help: ## 사용 가능한 명령 목록
 	@echo "Sessionary 통합 명령:"
 	@echo "  make install      - fe/be 의존성 설치"
+	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:5173) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
+	@echo "  make devdown      - 호스트 dev 앱(:8000,:5173) 종료 (인프라는 유지)"
+	@echo "  make infra-up     - 공유 로컬 인프라(db/redis/minio)만 기동"
+	@echo "  make infra-down   - 공유 인프라 중지 (볼륨 데이터 보존)"
 	@echo "  make test         - 백엔드 + 프론트엔드 전체 테스트"
 	@echo "  make test-be      - 백엔드 pytest"
 	@echo "  make test-fe      - 프론트엔드 유닛 + e2e"
@@ -27,6 +38,33 @@ help: ## 사용 가능한 명령 목록
 install: ## fe/be 의존성 설치
 	cd backend && uv sync
 	cd frontend && yarn install
+
+# --- 로컬 개발 --------------------------------------------------------------
+#
+# 전략: "단일 활성 + 공유 인프라".
+#  - 인프라(db/redis/minio)는 stateful & worktree 공용 → 한 벌만 띄워 공유.
+#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:5173) → 활성 worktree 하나에서만.
+# worktree 전환: 현재에서 Ctrl-C(또는 make devdown) → 다른 worktree 에서 make devup.
+# 인프라는 재사용되고 앱만 새로 뜬다.
+
+infra-up: ## 공유 로컬 인프라(db/redis/minio) 기동 — worktree 공용, idempotent
+	$(COMPOSE) up -d $(INFRA_SERVICES)
+
+infra-down: ## 공유 인프라 중지 (볼륨 데이터는 보존)
+	$(COMPOSE) stop $(INFRA_SERVICES)
+
+devup: infra-up ## 공유 인프라 + be/fe 개발 서버 동시 구동 (Ctrl-C 로 둘 다 종료)
+	cd backend && uv run alembic upgrade head
+	@echo "▶ backend(:8000) + frontend(:5173) 기동 — Ctrl-C 로 둘 다 종료"
+	@trap 'kill 0' INT TERM EXIT; \
+	(cd backend && uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
+	(cd frontend && yarn dev) & \
+	wait
+
+devdown: ## 호스트 dev 앱(:8000,:5173) 종료 — 인프라는 유지
+	-@pids=$$(lsof -ti tcp:8000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
+	-@pids=$$(lsof -ti tcp:5173); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
+	@echo "dev 앱 종료. 인프라까지 내리려면 make infra-down."
 
 # --- 테스트 -----------------------------------------------------------------
 

--- a/docs/domain/build-test.md
+++ b/docs/domain/build-test.md
@@ -106,11 +106,30 @@ bash infra/scripts/setup-staging-secrets.sh
 
 ## 로컬 개발
 
+### 빠른 시작 (권장): `make devup`
+```bash
+make devup    # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:5173) 동시 구동
+              # Ctrl-C 로 be/fe 둘 다 종료 (인프라는 유지)
+make devdown  # 호스트 dev 앱(:8000,:5173)만 종료, 인프라는 유지
+```
+
+**전략: 단일 활성 + 공유 인프라.** 인프라(db/redis/minio)는 stateful & worktree 공용이라
+`docker compose -p sessionary-dev` 로 한 벌만 띄워 모든 worktree가 공유한다. 앱(be/fe)은
+무상태 & 포트 고정(:8000/:5173)이라 활성 worktree 하나에서만 띄운다.
+worktree 전환: 현재에서 Ctrl-C → 다른 worktree 에서 `make devup` (인프라 재사용, 앱만 새로).
+여러 worktree 의 앱을 *동시에* 띄우려면 포트가 충돌하므로 단일 활성 모델을 쓴다.
+
+아래는 `make devup` 이 내부적으로 수행하는 단계다 (개별 실행/디버깅용).
+
 ### 인프라 시작 (Docker Compose)
 ```bash
-cd infra/dev
-docker compose up -d  # PostgreSQL, Redis, MinIO
+make infra-up   # = docker compose -p sessionary-dev -f infra/dev/docker-compose.yml up -d db auth-redis minio minio-init
+# 또는 수동:
+cd infra/dev && docker compose up -d  # PostgreSQL, Redis, MinIO (+ be/fe 컨테이너까지 전부)
 ```
+> 주의: `infra/dev/docker-compose.yml` 은 backend/frontend 컨테이너(:8000/:3000)도 정의한다.
+> 호스트에서 `uv run`/`yarn dev` 로 앱을 띄울 거면 인프라 서비스만 올려야 포트가 안 겹친다
+> (`make infra-up` 이 인프라만 선택해서 띄운다).
 
 ### Backend 개발 서버
 ```bash


### PR DESCRIPTION
## 개요
로컬 QA/개발용 풀스택 환경을 루트에서 한 번에 띄우는 Makefile 타깃을 추가한다. 여러 worktree 프로토타입 간 **빠른 context switch**를 목표로 "단일 활성 + 공유 인프라" 전략을 채택했다.

## 추가된 타깃
| 타깃 | 동작 |
|------|------|
| `make devup` | 공유 인프라 기동 → `alembic upgrade head` → be(uvicorn :8000) + fe(vite :5173) 동시 구동. `Ctrl-C` 로 둘 다 종료(trap) |
| `make devdown` | 호스트 dev 앱(:8000, :5173)만 종료. 인프라는 유지 |
| `make infra-up` | 공유 인프라(db/redis/minio/minio-init)만 기동. idempotent |
| `make infra-down` | 공유 인프라 중지 (볼륨 데이터 보존) |

## 설계: 단일 활성 + 공유 인프라
- `infra/dev/docker-compose.yml` 은 인프라뿐 아니라 be/fe 컨테이너(:8000/:3000)까지 풀스택을 정의한다 → 통째로 `up` 하면 호스트 앱과 포트 충돌. `make infra-up` 은 **인프라 서비스만** 선택 기동.
- 모든 `container_name` 이 고정이라 두 worktree 가 같은 스택을 동시에 올릴 수 없음 → 자연히 단일 활성 모델.
- 인프라는 stateful & 공용이므로 `docker compose -p sessionary-dev` 로 프로젝트명을 고정 → **어느 worktree 에서 실행하든 같은 인프라 한 벌(같은 데이터)** 공유.
- **worktree 전환**: 현재에서 `Ctrl-C` → 다른 worktree 에서 `make devup`. 인프라 재사용, 앱만 새로.

여러 worktree 앱을 *나란히* 띄우는 동시 다중은 vite 포트(`5173`)와 `PUBLIC_API_BASE_URL` 하드코딩을 env 기반 + 포트 offset 으로 바꿔야 해서 이번 범위에서 제외.

## 검증
- `make help` / `make -n {devup,infra-up,devdown}` — 생성 명령 의도대로 확인
- `make infra-up` 실제 기동 — db:5432 / auth-redis:6379 / minio:9000-9001 / minio-init **정상 Up**, be/fe 컨테이너는 미기동(의도대로)
- `devup` 의 be/fe 동시 구동은 장기 프로세스라 dry-run 으로 명령 정확성 확인

## 문서
`docs/domain/build-test.md` 로컬 개발 섹션을 `make devup` 권장 경로로 동기화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)