### PR TITLE
🐛 make devup 수정: 호스트 직접 실행 기동 실패 3건 (APP_ENV / 포트 / Redis)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ INFRA_SERVICES := db auth-redis minio minio-init
 # backend 는 APP_ENV 로 .env.{APP_ENV} 를 고른다. 미설정 시 app_env 기본값(prod)으로
 # 떨어져 .env.dev 를 못 읽으므로(설정 누락 에러) 호스트 직접 실행 시 명시해야 한다.
 APP_ENV ?= dev
+# 호스트 직접 실행은 compose 인프라를 localhost 로 접근한다. .env.dev 의 AUTH_REDIS_URL 은
+# 컨테이너 네트워크 호스트명(auth-redis)이라 호스트에서는 DNS 해석이 안 되므로 덮어쓴다.
+# (DATABASE_URL 은 .env.dev 가 이미 localhost 라 그대로 쓴다.)
+AUTH_REDIS_URL ?= redis://localhost:6379
+# devup 의 backend 명령에 공통으로 붙는 호스트-실행용 환경
+DEV_BE_ENV := APP_ENV=$(APP_ENV) AUTH_REDIS_URL=$(AUTH_REDIS_URL)
 
 help: ## 사용 가능한 명령 목록
 	@echo "Sessionary 통합 명령:"
@@ -59,10 +65,10 @@ infra-down: ## 공유 인프라 중지 (볼륨 데이터는 보존)
 	$(COMPOSE) stop $(INFRA_SERVICES)
 
 devup: infra-up ## 공유 인프라 + be/fe 개발 서버 동시 구동 (Ctrl-C 로 둘 다 종료)
-	cd backend && APP_ENV=$(APP_ENV) uv run alembic upgrade head
+	cd backend && $(DEV_BE_ENV) uv run alembic upgrade head
 	@echo "▶ backend(:8000) + frontend(:3000) 기동 — Ctrl-C 로 둘 다 종료"
 	@trap 'kill 0' INT TERM EXIT; \
-	(cd backend && APP_ENV=$(APP_ENV) uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
+	(cd backend && $(DEV_BE_ENV) uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
 	(cd frontend && yarn dev --port 3000 --strictPort) & \
 	wait
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 COMPOSE := docker compose -p sessionary-dev -f infra/dev/docker-compose.yml
 # stateful 인프라만 (앱 컨테이너 backend/frontend 는 호스트에서 직접 띄운다)
 INFRA_SERVICES := db auth-redis minio minio-init
+# backend 는 APP_ENV 로 .env.{APP_ENV} 를 고른다. 미설정 시 app_env 기본값(prod)으로
+# 떨어져 .env.dev 를 못 읽으므로(설정 누락 에러) 호스트 직접 실행 시 명시해야 한다.
+APP_ENV ?= dev
 
 help: ## 사용 가능한 명령 목록
 	@echo "Sessionary 통합 명령:"
@@ -54,10 +57,10 @@ infra-down: ## 공유 인프라 중지 (볼륨 데이터는 보존)
 	$(COMPOSE) stop $(INFRA_SERVICES)
 
 devup: infra-up ## 공유 인프라 + be/fe 개발 서버 동시 구동 (Ctrl-C 로 둘 다 종료)
-	cd backend && uv run alembic upgrade head
+	cd backend && APP_ENV=$(APP_ENV) uv run alembic upgrade head
 	@echo "▶ backend(:8000) + frontend(:5173) 기동 — Ctrl-C 로 둘 다 종료"
 	@trap 'kill 0' INT TERM EXIT; \
-	(cd backend && uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
+	(cd backend && APP_ENV=$(APP_ENV) uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
 	(cd frontend && yarn dev) & \
 	wait
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ APP_ENV ?= dev
 help: ## 사용 가능한 명령 목록
 	@echo "Sessionary 통합 명령:"
 	@echo "  make install      - fe/be 의존성 설치"
-	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:5173) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
-	@echo "  make devdown      - 호스트 dev 앱(:8000,:5173) 종료 (인프라는 유지)"
+	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:3000) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
+	@echo "  make devdown      - 호스트 dev 앱(:8000,:3000) 종료 (인프라는 유지)"
 	@echo "  make infra-up     - 공유 로컬 인프라(db/redis/minio)만 기동"
 	@echo "  make infra-down   - 공유 인프라 중지 (볼륨 데이터 보존)"
 	@echo "  make test         - 백엔드 + 프론트엔드 전체 테스트"
@@ -46,7 +46,9 @@ install: ## fe/be 의존성 설치
 #
 # 전략: "단일 활성 + 공유 인프라".
 #  - 인프라(db/redis/minio)는 stateful & worktree 공용 → 한 벌만 띄워 공유.
-#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:5173) → 활성 worktree 하나에서만.
+#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:3000) → 활성 worktree 하나에서만.
+#    fe 는 3000: Google OAuth redirect_uri 가 localhost:3000/oauth-callback 기준이라
+#    vite 기본값(5173) 대신 3000 으로 강제(--strictPort)해 콜백을 일치시킨다.
 # worktree 전환: 현재에서 Ctrl-C(또는 make devdown) → 다른 worktree 에서 make devup.
 # 인프라는 재사용되고 앱만 새로 뜬다.
 
@@ -58,15 +60,15 @@ infra-down: ## 공유 인프라 중지 (볼륨 데이터는 보존)
 
 devup: infra-up ## 공유 인프라 + be/fe 개발 서버 동시 구동 (Ctrl-C 로 둘 다 종료)
 	cd backend && APP_ENV=$(APP_ENV) uv run alembic upgrade head
-	@echo "▶ backend(:8000) + frontend(:5173) 기동 — Ctrl-C 로 둘 다 종료"
+	@echo "▶ backend(:8000) + frontend(:3000) 기동 — Ctrl-C 로 둘 다 종료"
 	@trap 'kill 0' INT TERM EXIT; \
 	(cd backend && APP_ENV=$(APP_ENV) uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
-	(cd frontend && yarn dev) & \
+	(cd frontend && yarn dev --port 3000 --strictPort) & \
 	wait
 
-devdown: ## 호스트 dev 앱(:8000,:5173) 종료 — 인프라는 유지
+devdown: ## 호스트 dev 앱(:8000,:3000) 종료 — 인프라는 유지
 	-@pids=$$(lsof -ti tcp:8000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
-	-@pids=$$(lsof -ti tcp:5173); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
+	-@pids=$$(lsof -ti tcp:3000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
 	@echo "dev 앱 종료. 인프라까지 내리려면 make infra-down."
 
 # --- 테스트 -----------------------------------------------------------------

--- a/docs/domain/build-test.md
+++ b/docs/domain/build-test.md
@@ -135,8 +135,9 @@ cd infra/dev && docker compose up -d  # PostgreSQL, Redis, MinIO (+ be/fe 컨테
 ```bash
 cd backend
 uv sync
-uv run alembic upgrade head
-uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000
+# APP_ENV=dev 를 줘야 .env.dev 를 읽는다 (app_env 기본값은 prod → 미설정 시 설정 누락 에러)
+APP_ENV=dev uv run alembic upgrade head
+APP_ENV=dev uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000
 ```
 
 ### Frontend 개발 서버

--- a/docs/domain/build-test.md
+++ b/docs/domain/build-test.md
@@ -108,14 +108,15 @@ bash infra/scripts/setup-staging-secrets.sh
 
 ### 빠른 시작 (권장): `make devup`
 ```bash
-make devup    # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:5173) 동시 구동
+make devup    # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:3000) 동시 구동
               # Ctrl-C 로 be/fe 둘 다 종료 (인프라는 유지)
-make devdown  # 호스트 dev 앱(:8000,:5173)만 종료, 인프라는 유지
+make devdown  # 호스트 dev 앱(:8000,:3000)만 종료, 인프라는 유지
 ```
 
 **전략: 단일 활성 + 공유 인프라.** 인프라(db/redis/minio)는 stateful & worktree 공용이라
 `docker compose -p sessionary-dev` 로 한 벌만 띄워 모든 worktree가 공유한다. 앱(be/fe)은
-무상태 & 포트 고정(:8000/:5173)이라 활성 worktree 하나에서만 띄운다.
+무상태 & 포트 고정(:8000/:3000)이라 활성 worktree 하나에서만 띄운다.
+fe 는 3000 으로 띄운다 (Google OAuth redirect_uri 가 `localhost:3000/oauth-callback` 기준).
 worktree 전환: 현재에서 Ctrl-C → 다른 worktree 에서 `make devup` (인프라 재사용, 앱만 새로).
 여러 worktree 의 앱을 *동시에* 띄우려면 포트가 충돌하므로 단일 활성 모델을 쓴다.
 
@@ -144,7 +145,7 @@ APP_ENV=dev uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000
 ```bash
 cd frontend
 yarn install
-yarn dev  # http://localhost:5173
+yarn dev --port 3000 --strictPort  # http://localhost:3000 (OAuth redirect_uri 가 3000 기준)
 ```
 
 ### API 클라이언트 재생성


### PR DESCRIPTION
QA용 `make devup`(#129)을 실제로 띄우며 발견한 호스트 직접 실행 기동 실패 3건을 수정한다. (docker-compose 경로는 정상이나, devup 의 호스트 직접 실행 경로에 누락/불일치가 있었다.)

## 1. backend 설정 로드 실패 (APP_ENV 누락)
`app_env` 기본값이 `prod`라 `APP_ENV=dev` 가 있어야 `.env.dev` 를 읽는데 devup 이 주입하지 않아 `database_url`/`secret_key` 등 누락 검증 에러.
→ `APP_ENV ?= dev` + backend 명령에 주입.

## 2. Google OAuth 콜백 실패 (frontend 포트 불일치)
`GOOGLE_OAUTH_REDIRECT_URI=localhost:3000/oauth-callback` 인데 vite 기본 포트(5173)로 떠서 콜백이 빈 포트로 가 연결 실패.
→ frontend 를 `yarn dev --port 3000 --strictPort` 로, devdown 종료 포트도 3000.

## 3. OAuth 콜백 500 (Redis 호스트명 불일치)
`.env.dev` 의 `AUTH_REDIS_URL=redis://auth-redis:6379` 는 compose 네트워크 호스트명이라 호스트 직접 실행 시 DNS 해석 실패 → 로그인 콜백에서 `redis.ConnectionError` 500.
→ `AUTH_REDIS_URL ?= redis://localhost:6379` 로 덮어써 backend 명령에 적용. (DATABASE_URL 은 `.env.dev` 가 이미 localhost 라 그대로)

## 문서
- `docs/domain/build-test.md`: devup/devdown 및 수동 절차에 `APP_ENV=dev`·포트 3000 반영. (Playwright e2e dev 서버 포트 5173 은 무관, 유지)

## 검증
- `make -n devup` — `APP_ENV=dev AUTH_REDIS_URL=redis://localhost:6379 uv run alembic/uvicorn ...`, `yarn dev --port 3000 --strictPort` 주입 확인
- 실제 기동: backend `:8000` startup·`/docs` 200, frontend `:3000`·`/oauth-callback` 200, Redis `PONG`, 영상 스트리밍 206 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)