### PR TITLE
🔧 make devup: 호스트 frontend dev 포트를 3100으로 변경 (FE_PORT 변수화)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,20 @@ APP_ENV ?= dev
 # 컨테이너 네트워크 호스트명(auth-redis)이라 호스트에서는 DNS 해석이 안 되므로 덮어쓴다.
 # (DATABASE_URL 은 .env.dev 가 이미 localhost 라 그대로 쓴다.)
 AUTH_REDIS_URL ?= redis://localhost:6379
+# 호스트 frontend dev 포트. 다른 로컬 프로젝트와의 충돌을 피하려 3000 대신 3100 을 기본값으로 쓴다.
+# (compose 경로는 여전히 3000:5173 매핑을 쓰므로 .env.dev 의 OAuth redirect 기본값은 3000 으로 둔다.)
+FE_PORT ?= 3100
+# 호스트 직접 실행 시 OAuth redirect_uri 를 실제 fe 포트로 맞춘다. .env.dev 값(compose 기본 3000)을 덮어쓴다.
+# 주의: 이 redirect_uri 가 Google Cloud Console 의 승인된 리디렉션 URI 에 등록돼 있어야 로그인이 동작한다.
+GOOGLE_OAUTH_REDIRECT_URI ?= http://localhost:$(FE_PORT)/oauth-callback
 # devup 의 backend 명령에 공통으로 붙는 호스트-실행용 환경
-DEV_BE_ENV := APP_ENV=$(APP_ENV) AUTH_REDIS_URL=$(AUTH_REDIS_URL)
+DEV_BE_ENV := APP_ENV=$(APP_ENV) AUTH_REDIS_URL=$(AUTH_REDIS_URL) GOOGLE_OAUTH_REDIRECT_URI=$(GOOGLE_OAUTH_REDIRECT_URI)
 
 help: ## 사용 가능한 명령 목록
 	@echo "Sessionary 통합 명령:"
 	@echo "  make install      - fe/be 의존성 설치"
-	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:3000) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
-	@echo "  make devdown      - 호스트 dev 앱(:8000,:3000) 종료 (인프라는 유지)"
+	@echo "  make devup        - 공유 인프라 + be(:8000)/fe(:$(FE_PORT)) 개발 서버 동시 구동 (Ctrl-C 로 종료)"
+	@echo "  make devdown      - 호스트 dev 앱(:8000,:$(FE_PORT)) 종료 (인프라는 유지)"
 	@echo "  make infra-up     - 공유 로컬 인프라(db/redis/minio)만 기동"
 	@echo "  make infra-down   - 공유 인프라 중지 (볼륨 데이터 보존)"
 	@echo "  make test         - 백엔드 + 프론트엔드 전체 테스트"
@@ -52,9 +58,10 @@ install: ## fe/be 의존성 설치
 #
 # 전략: "단일 활성 + 공유 인프라".
 #  - 인프라(db/redis/minio)는 stateful & worktree 공용 → 한 벌만 띄워 공유.
-#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:3000) → 활성 worktree 하나에서만.
-#    fe 는 3000: Google OAuth redirect_uri 가 localhost:3000/oauth-callback 기준이라
-#    vite 기본값(5173) 대신 3000 으로 강제(--strictPort)해 콜백을 일치시킨다.
+#  - 앱(be/fe)은 무상태 & 포트 고정(:8000/:$(FE_PORT)) → 활성 worktree 하나에서만.
+#    fe 는 FE_PORT(기본 3100)로 강제(--strictPort)하고, devup 이 OAuth redirect_uri 를
+#    그 포트로 주입(GOOGLE_OAUTH_REDIRECT_URI)해 콜백을 일치시킨다. vite 기본값(5173)은 안 쓴다.
+#    포트를 바꾸려면 `make devup FE_PORT=3000` 처럼 오버라이드한다.
 # worktree 전환: 현재에서 Ctrl-C(또는 make devdown) → 다른 worktree 에서 make devup.
 # 인프라는 재사용되고 앱만 새로 뜬다.
 
@@ -66,15 +73,15 @@ infra-down: ## 공유 인프라 중지 (볼륨 데이터는 보존)
 
 devup: infra-up ## 공유 인프라 + be/fe 개발 서버 동시 구동 (Ctrl-C 로 둘 다 종료)
 	cd backend && $(DEV_BE_ENV) uv run alembic upgrade head
-	@echo "▶ backend(:8000) + frontend(:3000) 기동 — Ctrl-C 로 둘 다 종료"
+	@echo "▶ backend(:8000) + frontend(:$(FE_PORT)) 기동 — Ctrl-C 로 둘 다 종료"
 	@trap 'kill 0' INT TERM EXIT; \
 	(cd backend && $(DEV_BE_ENV) uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000) & \
-	(cd frontend && yarn dev --port 3000 --strictPort) & \
+	(cd frontend && VITE_HMR_CLIENT_PORT=$(FE_PORT) yarn dev --port $(FE_PORT) --strictPort) & \
 	wait
 
-devdown: ## 호스트 dev 앱(:8000,:3000) 종료 — 인프라는 유지
+devdown: ## 호스트 dev 앱(:8000,:$(FE_PORT)) 종료 — 인프라는 유지
 	-@pids=$$(lsof -ti tcp:8000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
-	-@pids=$$(lsof -ti tcp:3000); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
+	-@pids=$$(lsof -ti tcp:$(FE_PORT)); [ -n "$$pids" ] && kill $$pids 2>/dev/null || true
 	@echo "dev 앱 종료. 인프라까지 내리려면 make infra-down."
 
 # --- 테스트 -----------------------------------------------------------------

--- a/docs/domain/build-test.md
+++ b/docs/domain/build-test.md
@@ -108,15 +108,19 @@ bash infra/scripts/setup-staging-secrets.sh
 
 ### 빠른 시작 (권장): `make devup`
 ```bash
-make devup    # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:3000) 동시 구동
-              # Ctrl-C 로 be/fe 둘 다 종료 (인프라는 유지)
-make devdown  # 호스트 dev 앱(:8000,:3000)만 종료, 인프라는 유지
+make devup            # 공유 인프라 기동 + 마이그레이션 + be(:8000)/fe(:3100) 동시 구동
+                      # Ctrl-C 로 be/fe 둘 다 종료 (인프라는 유지)
+make devup FE_PORT=3000   # 포트 오버라이드 (다른 로컬 프로젝트와 충돌 시 조절)
+make devdown          # 호스트 dev 앱(:8000,:3100)만 종료, 인프라는 유지
 ```
 
 **전략: 단일 활성 + 공유 인프라.** 인프라(db/redis/minio)는 stateful & worktree 공용이라
 `docker compose -p sessionary-dev` 로 한 벌만 띄워 모든 worktree가 공유한다. 앱(be/fe)은
-무상태 & 포트 고정(:8000/:3000)이라 활성 worktree 하나에서만 띄운다.
-fe 는 3000 으로 띄운다 (Google OAuth redirect_uri 가 `localhost:3000/oauth-callback` 기준).
+무상태 & 포트 고정(:8000/:`FE_PORT`)이라 활성 worktree 하나에서만 띄운다.
+fe 는 `FE_PORT`(기본 3100)로 띄우고, devup 이 OAuth redirect_uri 를 그 포트로 주입한다
+(`GOOGLE_OAUTH_REDIRECT_URI=http://localhost:$FE_PORT/oauth-callback`). 기본 3000 대신 3100 을
+쓰는 이유는 다른 로컬 프로젝트(3000 사용)와의 충돌을 피하기 위함. **새 포트는 Google Cloud
+Console 의 승인된 리디렉션 URI 에 `http://localhost:3100/oauth-callback` 가 등록돼 있어야 로그인이 된다.**
 worktree 전환: 현재에서 Ctrl-C → 다른 worktree 에서 `make devup` (인프라 재사용, 앱만 새로).
 여러 worktree 의 앱을 *동시에* 띄우려면 포트가 충돌하므로 단일 활성 모델을 쓴다.
 
@@ -128,7 +132,7 @@ make infra-up   # = docker compose -p sessionary-dev -f infra/dev/docker-compose
 # 또는 수동:
 cd infra/dev && docker compose up -d  # PostgreSQL, Redis, MinIO (+ be/fe 컨테이너까지 전부)
 ```
-> 주의: `infra/dev/docker-compose.yml` 은 backend/frontend 컨테이너(:8000/:3000)도 정의한다.
+> 주의: `infra/dev/docker-compose.yml` 은 backend/frontend 컨테이너(:8000/:3000, 호스트 3000→컨테이너 5173)도 정의한다.
 > 호스트에서 `uv run`/`yarn dev` 로 앱을 띄울 거면 인프라 서비스만 올려야 포트가 안 겹친다
 > (`make infra-up` 이 인프라만 선택해서 띄운다).
 
@@ -145,7 +149,9 @@ APP_ENV=dev uv run uvicorn app.main:get_app --reload --host 0.0.0.0 --port 8000
 ```bash
 cd frontend
 yarn install
-yarn dev --port 3000 --strictPort  # http://localhost:3000 (OAuth redirect_uri 가 3000 기준)
+VITE_HMR_CLIENT_PORT=3100 yarn dev --port 3100 --strictPort  # http://localhost:3100
+# 단독 실행 시 backend 에 동일 포트의 redirect_uri 를 줘야 한다:
+#   GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3100/oauth-callback ... uvicorn ...
 ```
 
 ### API 클라이언트 재생성

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
 		host: '0.0.0.0',
 		port: 5173,
 		hmr: {
-			clientPort: 3000
+			// compose 경로는 3000:5173 매핑이라 기본 3000. 호스트 devup 은 VITE_HMR_CLIENT_PORT 로 실제 fe 포트를 넘긴다.
+			clientPort: Number(process.env.VITE_HMR_CLIENT_PORT) || 3000
 		},
 		watch: {
 			usePolling: true


### PR DESCRIPTION
## 개요
호스트 `make devup` 의 frontend dev 포트를 **3000 → 3100**(기본값)으로 옮기고 `FE_PORT` 변수로 일반화. 다른 로컬 프로젝트가 3000 을 점유할 때 `vite --strictPort` 충돌을 피하기 위함.

## 변경
- **Makefile**: `FE_PORT ?= 3100` 변수화. `devup`/`devdown`/`help`/주석을 `FE_PORT` 로 일반화. `make devup FE_PORT=3000` 처럼 오버라이드 가능.
- **OAuth redirect 주입**: devup 이 backend 에 `GOOGLE_OAUTH_REDIRECT_URI=http://localhost:$(FE_PORT)/oauth-callback` 주입 (기존 `APP_ENV`/`AUTH_REDIS_URL` 주입 패턴과 동일). `.env.dev` 의 compose 기본값(3000)은 보존 → **compose 경로 무영향**.
- **vite.config.ts**: HMR `clientPort` 를 `VITE_HMR_CLIENT_PORT` env 로 오버라이드 가능하게. 미설정 시 3000(compose 기본) 유지.
- **docs/domain/build-test.md**: 포트/주입/Console 안내 갱신.

## ⚠️ 사용자 액션 필요
새 포트로 **로그인**하려면 Google Cloud Console 의 *승인된 리디렉션 URI* 에 `http://localhost:3100/oauth-callback` 를 추가해야 합니다. (없으면 `redirect_uri_mismatch`)

## 검증
- `make -n devup` dry-run: backend 에 redirect 주입, frontend `--port 3100`, help 표기 3100 확인.
- compose 경로(`infra/dev/docker-compose.yml` 3000:5173)와 staging(`fly-frontend.toml` internal_port 3000)은 의도적으로 미변경.