### PR TITLE
🐛 5xx 에러 응답에 CORS 헤더 보장 (#113)

### DIFF
--- a/backend/app/core/errors/server_error.py
+++ b/backend/app/core/errors/server_error.py
@@ -1,0 +1,16 @@
+from loguru import logger
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
+
+
+async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.opt(exception=exc).error(
+        "Unhandled exception on {method} {path}",
+        method=request.method,
+        path=request.url.path,
+    )
+    return JSONResponse(
+        {"errors": ["Internal server error"]},
+        status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.errors import ServerErrorMiddleware
 
 from app.auth import view as auth_view
 from app.auth.access import (
@@ -10,6 +11,7 @@ from app.auth.access import (
 )
 from app.containers.application import ApplicationContainer
 from app.core.errors.http_error import http_error_handler
+from app.core.errors.server_error import unhandled_error_handler
 from app.core.errors.validation_error import http400_error_handler
 from app.core.middlewares import AuthSessionMiddleware
 from app.curation import view as curation_view
@@ -58,15 +60,23 @@ def get_application(container: ApplicationContainer | None = None) -> FastAPI:
         auth_backend.components.current_user(optional=True)
     )
 
+    # add_middleware prepends, so the last call is the outermost layer.
+    # Order (outer -> inner): CORS -> AuthSession -> ServerError.
+    # The inner ServerErrorMiddleware converts unhandled 5xx into a JSONResponse
+    # that flows back out through CORSMiddleware, keeping the
+    # Access-Control-Allow-Origin header on 5xx responses.
+    application.add_middleware(
+        ServerErrorMiddleware, handler=unhandled_error_handler
+    )
+    application.add_middleware(
+        AuthSessionMiddleware, settings=settings, auth_backend=auth_backend
+    )
     application.add_middleware(
         CORSMiddleware,
         allow_origins=settings.allowed_hosts,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
-    )
-    application.add_middleware(
-        AuthSessionMiddleware, settings=settings, auth_backend=auth_backend
     )
 
     application.add_exception_handler(HTTPException, http_error_handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,15 +61,22 @@ def get_application(container: ApplicationContainer | None = None) -> FastAPI:
     )
 
     # add_middleware prepends, so the last call is the outermost layer.
-    # Order (outer -> inner): CORS -> AuthSession -> ServerError.
-    # The inner ServerErrorMiddleware converts unhandled 5xx into a JSONResponse
-    # that flows back out through CORSMiddleware, keeping the
-    # Access-Control-Allow-Origin header on 5xx responses.
-    application.add_middleware(
-        ServerErrorMiddleware, handler=unhandled_error_handler
-    )
+    # Final stack (outer -> inner): CORS -> ServerError -> AuthSession.
+    #
+    # AuthSessionMiddleware는 redis.get/ttl/write_token 등에서 예외를 전파할 수
+    # 있다(Redis 장애·세션 데이터 손상 시). ServerErrorMiddleware가 AuthSession보다
+    # 바깥에 있어야 해당 예외를 JSONResponse로 변환한 뒤 CORSMiddleware를 통과시켜
+    # Access-Control-Allow-Origin 헤더를 보장한다.
+    #
+    # add 순서 (prepend이므로 역순이 실행 순서):
+    #   1. AuthSessionMiddleware  → 가장 안쪽 (먼저 add)
+    #   2. ServerErrorMiddleware  → AuthSession 바깥
+    #   3. CORSMiddleware         → 가장 바깥 (마지막 add)
     application.add_middleware(
         AuthSessionMiddleware, settings=settings, auth_backend=auth_backend
+    )
+    application.add_middleware(
+        ServerErrorMiddleware, handler=unhandled_error_handler
     )
     application.add_middleware(
         CORSMiddleware,

--- a/backend/tests/api/test_cors_error.py
+++ b/backend/tests/api/test_cors_error.py
@@ -1,8 +1,11 @@
 from typing import AsyncGenerator
+from unittest.mock import AsyncMock, patch
 
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 import pytest
+
+from app.core.middlewares import AuthSessionMiddleware
 
 ALLOWED_ORIGIN = "http://testorigin.example"
 
@@ -52,4 +55,40 @@ async def test_200_response_still_includes_cors_header(client: AsyncClient):
     response = await client.get("/ping", headers={"Origin": ALLOWED_ORIGIN})
 
     assert response.status_code == 200
+    assert "access-control-allow-origin" in response.headers
+
+
+@pytest.fixture
+async def auth_session_error_client(app: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+    """AuthSessionMiddleware.dispatch가 RuntimeError를 던지는 클라이언트.
+
+    ServerErrorMiddleware가 AuthSession보다 바깥에 있을 때만 CORS 헤더가 붙는다.
+    미들웨어 순서가 잘못되면 이 테스트는 CORS 헤더 없이 500을 받아 실패한다.
+    """
+
+    async def _raise(*args, **kwargs):
+        raise RuntimeError("simulated AuthSessionMiddleware failure")
+
+    with patch.object(AuthSessionMiddleware, "dispatch", new=AsyncMock(side_effect=_raise)):
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://testserver",
+            headers={"Content-Type": "application/json"},
+        ) as client:
+            yield client
+
+
+async def test_auth_session_middleware_error_includes_cors_header(
+    auth_session_error_client: AsyncClient,
+):
+    """AuthSessionMiddleware 내부 예외 시에도 5xx 응답에 CORS 헤더가 붙어야 한다.
+
+    수정 전(ServerError가 AuthSession 안쪽): 이 테스트는 FAIL.
+    수정 후(ServerError가 AuthSession 바깥): 이 테스트는 PASS.
+    """
+    response = await auth_session_error_client.get(
+        "/ping", headers={"Origin": ALLOWED_ORIGIN}
+    )
+
+    assert response.status_code == 500
     assert "access-control-allow-origin" in response.headers

--- a/backend/tests/api/test_cors_error.py
+++ b/backend/tests/api/test_cors_error.py
@@ -1,0 +1,55 @@
+from typing import AsyncGenerator
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+ALLOWED_ORIGIN = "http://testorigin.example"
+
+
+@pytest.fixture
+async def app_with_failing_route(app: FastAPI) -> FastAPI:
+    async def _boom():
+        raise RuntimeError("internal secret detail should not leak")
+
+    app.add_api_route("/_test_boom", _boom, methods=["GET"])
+    return app
+
+
+@pytest.fixture
+async def error_client(
+    app_with_failing_route: FastAPI,
+) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(
+            app=app_with_failing_route, raise_app_exceptions=False
+        ),
+        base_url="http://testserver",
+        headers={"Content-Type": "application/json"},
+    ) as client:
+        yield client
+
+
+async def test_5xx_response_includes_cors_header(error_client: AsyncClient):
+    response = await error_client.get(
+        "/_test_boom", headers={"Origin": ALLOWED_ORIGIN}
+    )
+
+    assert response.status_code == 500
+    assert "access-control-allow-origin" in response.headers
+
+
+async def test_5xx_response_does_not_leak_internal_detail(error_client: AsyncClient):
+    response = await error_client.get(
+        "/_test_boom", headers={"Origin": ALLOWED_ORIGIN}
+    )
+
+    assert response.status_code == 500
+    assert "internal secret detail should not leak" not in response.text
+
+
+async def test_200_response_still_includes_cors_header(client: AsyncClient):
+    response = await client.get("/ping", headers={"Origin": ALLOWED_ORIGIN})
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" in response.headers


### PR DESCRIPTION
## 개요
Closes #113

처리되지 않은 예외로 5xx(특히 500)가 발생하면 응답이 `CORSMiddleware`를 거치지 않아 `Access-Control-Allow-Origin` 헤더가 누락되던 문제를 해결합니다. 그 결과 브라우저가 모든 서버 5xx를 "CORS 차단"으로 오인 표시하고, 프론트가 실제 status/에러 바디를 읽지 못했습니다.

## 원인
Starlette 미들웨어 스택에서 최상위 자동 `ServerErrorMiddleware`가 `CORSMiddleware`보다 **바깥**에 위치 → 처리되지 않은 예외로 생성된 5xx 응답에 CORS 헤더가 붙지 않음.

## 해결
- 명시적 `ServerErrorMiddleware`(커스텀 `unhandled_error_handler`)를 `CORSMiddleware` **안쪽**에 추가.
- 처리되지 않은 5xx를 안쪽에서 `JSONResponse`로 변환 → 응답이 `CORSMiddleware`를 거쳐 나가며 `Access-Control-Allow-Origin` 헤더가 유지됨.
- 핸들러는 내부 예외 detail을 바디에 노출하지 않고(`{"errors": ["Internal server error"]}`), loguru로 예외를 로깅.
- 부수 효과: 이제 CORS가 가장 바깥 레이어가 되어 인증 실패 등 다른 응답에도 CORS 헤더가 일관되게 붙습니다.

## 변경
- `backend/app/core/errors/server_error.py` (신규): `unhandled_error_handler`
- `backend/app/main.py`: 미들웨어 순서 조정 + 내부 `ServerErrorMiddleware` 등록
- `backend/tests/api/test_cors_error.py` (신규): 5xx CORS 헤더 / detail 비노출 / 200 회귀 검증

## 테스트
- 신규 테스트 3건 통과 (RED → GREEN 사이클로 개발)
- 전체 백엔드 `uv run pytest tests`: **90 passed**

## 범위 외
- (선택) 프론트 `SessionList.svelte` 5xx 토스트 피드백은 별도 작업으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)