### PR TITLE
✨ 렉처 진행도 패널 실데이터 수집: 시청 위치/부분 진행도 트래킹 + 90% 완료 (#133)

### DIFF
--- a/backend/app/containers/services.py
+++ b/backend/app/containers/services.py
@@ -114,6 +114,7 @@ class ServicesContainer(containers.DeclarativeContainer):
     progress_service = providers.Factory(
         ProgressService,
         repository=progress_repository,
+        lecture_service=lecture_service,
     )
 
     video_provider = providers.Factory(

--- a/backend/app/db/migrations/versions/2026_06_22_add_lesson_progress_position.py
+++ b/backend/app/db/migrations/versions/2026_06_22_add_lesson_progress_position.py
@@ -1,0 +1,59 @@
+"""add partial-progress fields to lesson_progress
+
+부분 진행도(이어보기 위치/영상 길이/누적 시청률) + 미완료 행 허용(completed_at nullable).
+
+Revision ID: add_progress_position_001
+Revises: convert_subtitle_ts_001
+Create Date: 2026-06-22
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_progress_position_001"
+down_revision = "convert_subtitle_ts_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("lesson_progress") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_position_sec",
+                sa.Integer(),
+                server_default="0",
+                nullable=False,
+            )
+        )
+        batch_op.add_column(
+            sa.Column("duration_sec", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "progress_percent",
+                sa.Integer(),
+                server_default="0",
+                nullable=False,
+            )
+        )
+        batch_op.alter_column(
+            "completed_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("lesson_progress") as batch_op:
+        batch_op.alter_column(
+            "completed_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        )
+        batch_op.drop_column("progress_percent")
+        batch_op.drop_column("duration_sec")
+        batch_op.drop_column("last_position_sec")

--- a/backend/app/db/tables.py
+++ b/backend/app/db/tables.py
@@ -298,8 +298,15 @@ class LessonProgress(Base):
     lecture_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("lecture.id"), nullable=False
     )
-    completed_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True), default=func.now(), nullable=False
+    last_position_sec: Mapped[int] = mapped_column(
+        Integer, default=0, server_default="0", nullable=False
+    )
+    duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    progress_percent: Mapped[int] = mapped_column(
+        Integer, default=0, server_default="0", nullable=False
+    )
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
     __tablename__ = "lesson_progress"

--- a/backend/app/progress/models.py
+++ b/backend/app/progress/models.py
@@ -1,9 +1,24 @@
 from app.core.models import BaseModel
 
 
+class LessonProgressItem(BaseModel):
+    lesson_id: int
+    percent: int
+    completed: bool
+    last_position_sec: int
+
+
 class LectureProgressData(BaseModel):
     completed_count: int
     total_count: int
     percent: int
     next_lesson_id: int | None
     completed_lesson_ids: list[int]
+    lessons: list[LessonProgressItem]
+    resume_lesson_id: int | None
+    resume_position_sec: int
+
+
+class PositionReport(BaseModel):
+    position_sec: int
+    duration_sec: int

--- a/backend/app/progress/repository.py
+++ b/backend/app/progress/repository.py
@@ -6,10 +6,28 @@ from sqlalchemy import delete, func, select
 from app.db import tables as tb
 from app.db.session import SessionManager
 
+COMPLETION_THRESHOLD_PERCENT = 90
+
 
 class BaseProgressRepository(abc.ABC):
     def __init__(self, session_manager: SessionManager) -> None:
         self._session_manager = session_manager
+
+    @abc.abstractmethod
+    async def upsert_position(
+        self,
+        user_id: uuid.UUID,
+        lesson_id: int,
+        position_sec: int,
+        duration_sec: int,
+    ) -> tb.LessonProgress:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def get_progress_rows(
+        self, user_id: uuid.UUID, lecture_id: int
+    ) -> list[tb.LessonProgress]:
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def get_completed_lesson_ids(
@@ -84,3 +102,64 @@ class ProgressRepository(BaseProgressRepository):
                 )
             )
             await session.commit()
+
+    async def upsert_position(
+        self,
+        user_id: uuid.UUID,
+        lesson_id: int,
+        position_sec: int,
+        duration_sec: int,
+    ) -> tb.LessonProgress:
+        new_percent = (
+            round(position_sec / duration_sec * 100) if duration_sec > 0 else 0
+        )
+
+        async with self._session_manager.async_session() as session:
+            existing = await session.execute(
+                select(tb.LessonProgress).where(
+                    tb.LessonProgress.user_id == user_id,
+                    tb.LessonProgress.lesson_id == lesson_id,
+                )
+            )
+            progress = existing.scalar_one_or_none()
+
+            if progress is None:
+                lecture_id = (
+                    await session.execute(
+                        select(tb.Lesson.lecture_id).where(tb.Lesson.id == lesson_id)
+                    )
+                ).scalar_one()
+                progress = tb.LessonProgress(
+                    user_id=user_id,
+                    lesson_id=lesson_id,
+                    lecture_id=lecture_id,
+                    progress_percent=0,
+                )
+                session.add(progress)
+
+            progress.last_position_sec = position_sec
+            progress.duration_sec = duration_sec
+            progress.progress_percent = max(progress.progress_percent, new_percent)
+
+            if (
+                progress.progress_percent >= COMPLETION_THRESHOLD_PERCENT
+                and progress.completed_at is None
+            ):
+                progress.completed_at = func.now()
+
+            await session.flush()
+            await session.commit()
+            await session.refresh(progress)
+            return progress
+
+    async def get_progress_rows(
+        self, user_id: uuid.UUID, lecture_id: int
+    ) -> list[tb.LessonProgress]:
+        async with self._session_manager.async_session() as session:
+            result = await session.execute(
+                select(tb.LessonProgress).where(
+                    tb.LessonProgress.user_id == user_id,
+                    tb.LessonProgress.lecture_id == lecture_id,
+                )
+            )
+            return list(result.scalars().all())

--- a/backend/app/progress/repository.py
+++ b/backend/app/progress/repository.py
@@ -1,7 +1,7 @@
 import abc
 import uuid
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 
 from app.db import tables as tb
 from app.db.session import SessionManager
@@ -37,6 +37,7 @@ class ProgressRepository(BaseProgressRepository):
                 select(tb.LessonProgress.lesson_id).where(
                     tb.LessonProgress.user_id == user_id,
                     tb.LessonProgress.lecture_id == lecture_id,
+                    tb.LessonProgress.completed_at.is_not(None),
                 )
             )
             return list(result.scalars().all())
@@ -65,6 +66,8 @@ class ProgressRepository(BaseProgressRepository):
                 user_id=user_id,
                 lesson_id=lesson_id,
                 lecture_id=lecture_id,
+                progress_percent=100,
+                completed_at=func.now(),
             )
             session.add(progress)
             await session.flush()

--- a/backend/app/progress/service.py
+++ b/backend/app/progress/service.py
@@ -2,13 +2,19 @@ import uuid
 
 from app.db import tables as tb
 from app.lecture.models import LectureDetail
-from app.progress.models import LectureProgressData
+from app.lecture.service import BaseLectureService
+from app.progress.models import LectureProgressData, LessonProgressItem
 from app.progress.repository import BaseProgressRepository
 
 
 class ProgressService:
-    def __init__(self, repository: BaseProgressRepository) -> None:
+    def __init__(
+        self,
+        repository: BaseProgressRepository,
+        lecture_service: BaseLectureService,
+    ) -> None:
         self.repository = repository
+        self.lecture_service = lecture_service
 
     async def get_lecture_progress(
         self, user_id: uuid.UUID, lecture: LectureDetail
@@ -17,30 +23,68 @@ class ProgressService:
         lesson_ids = [lesson.id for lesson in lessons]
         total_count = len(lessons)
 
-        completed_all = await self.repository.get_completed_lesson_ids(
-            user_id, lecture.id
-        )
-        completed_set = set(completed_all)
-        completed_lesson_ids = [lid for lid in lesson_ids if lid in completed_set]
-        completed_count = len(completed_lesson_ids)
+        rows = await self.repository.get_progress_rows(user_id, lecture.id)
+        rows_by_lesson = {row.lesson_id: row for row in rows}
 
+        lesson_items: list[LessonProgressItem] = []
+        completed_lesson_ids: list[int] = []
+        for lesson_id in lesson_ids:
+            row = rows_by_lesson.get(lesson_id)
+            completed = row is not None and row.completed_at is not None
+            if completed:
+                completed_lesson_ids.append(lesson_id)
+            lesson_items.append(
+                LessonProgressItem(
+                    lesson_id=lesson_id,
+                    percent=row.progress_percent if row is not None else 0,
+                    completed=completed,
+                    last_position_sec=row.last_position_sec if row is not None else 0,
+                )
+            )
+
+        completed_count = len(completed_lesson_ids)
         percent = (
             round(completed_count / total_count * 100) if total_count > 0 else 0
         )
 
-        next_lesson_id = next(
+        completed_set = set(completed_lesson_ids)
+        resume_lesson_id = next(
             (lid for lid in lesson_ids if lid not in completed_set), None
+        )
+        resume_row = (
+            rows_by_lesson.get(resume_lesson_id)
+            if resume_lesson_id is not None
+            else None
+        )
+        resume_position_sec = (
+            resume_row.last_position_sec if resume_row is not None else 0
         )
 
         return LectureProgressData(
             completed_count=completed_count,
             total_count=total_count,
             percent=percent,
-            next_lesson_id=next_lesson_id,
+            next_lesson_id=resume_lesson_id,
             completed_lesson_ids=completed_lesson_ids,
+            lessons=lesson_items,
+            resume_lesson_id=resume_lesson_id,
+            resume_position_sec=resume_position_sec,
         )
 
     async def mark_complete(
         self, user_id: uuid.UUID, lesson_id: int
     ) -> tb.LessonProgress:
         return await self.repository.mark_complete(user_id, lesson_id)
+
+    async def report_position(
+        self,
+        user_id: uuid.UUID,
+        lesson_id: int,
+        position_sec: int,
+        duration_sec: int,
+    ) -> LectureProgressData:
+        progress = await self.repository.upsert_position(
+            user_id, lesson_id, position_sec, duration_sec
+        )
+        lecture = await self.lecture_service.get_lecture_detail(progress.lecture_id)
+        return await self.get_lecture_progress(user_id, lecture)

--- a/backend/app/progress/view.py
+++ b/backend/app/progress/view.py
@@ -5,7 +5,7 @@ from app.auth.access import authenticated_user
 from app.containers.application import ApplicationContainer
 from app.db.tables import User
 from app.lecture.service import BaseLectureService
-from app.progress.models import LectureProgressData
+from app.progress.models import LectureProgressData, PositionReport
 from app.progress.service import ProgressService
 
 app_router = APIRouter()
@@ -30,3 +30,22 @@ async def mark_lesson_complete(
     progress = await progress_service.mark_complete(user.id, lesson_id)
     lecture = await lecture_service.get_lecture_detail(progress.lecture_id)
     return await progress_service.get_lecture_progress(user.id, lecture)
+
+
+@app_router.put(
+    "/lesson/{lesson_id}/position",
+    response_model=LectureProgressData,
+    responses={401: {"description": "Missing token or inactive user."}},
+)
+@inject
+async def report_lesson_position(
+    lesson_id: int,
+    report: PositionReport,
+    user: User = Depends(authenticated_user),
+    progress_service: ProgressService = Depends(
+        Provide[ApplicationContainer.services.progress_service]
+    ),
+):
+    return await progress_service.report_position(
+        user.id, lesson_id, report.position_sec, report.duration_sec
+    )

--- a/backend/app/progress/view.py
+++ b/backend/app/progress/view.py
@@ -1,5 +1,6 @@
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import NoResultFound
 
 from app.auth.access import authenticated_user
 from app.containers.application import ApplicationContainer
@@ -14,7 +15,10 @@ app_router = APIRouter()
 @app_router.post(
     "/lesson/{lesson_id}",
     response_model=LectureProgressData,
-    responses={401: {"description": "Missing token or inactive user."}},
+    responses={
+        401: {"description": "Missing token or inactive user."},
+        404: {"description": "Lesson not found."},
+    },
 )
 @inject
 async def mark_lesson_complete(
@@ -27,7 +31,10 @@ async def mark_lesson_complete(
         Provide[ApplicationContainer.services.lecture_service]
     ),
 ):
-    progress = await progress_service.mark_complete(user.id, lesson_id)
+    try:
+        progress = await progress_service.mark_complete(user.id, lesson_id)
+    except NoResultFound:
+        raise HTTPException(status_code=404, detail="Lesson not found")
     lecture = await lecture_service.get_lecture_detail(progress.lecture_id)
     return await progress_service.get_lecture_progress(user.id, lecture)
 
@@ -35,7 +42,10 @@ async def mark_lesson_complete(
 @app_router.put(
     "/lesson/{lesson_id}/position",
     response_model=LectureProgressData,
-    responses={401: {"description": "Missing token or inactive user."}},
+    responses={
+        401: {"description": "Missing token or inactive user."},
+        404: {"description": "Lesson not found."},
+    },
 )
 @inject
 async def report_lesson_position(
@@ -46,6 +56,9 @@ async def report_lesson_position(
         Provide[ApplicationContainer.services.progress_service]
     ),
 ):
-    return await progress_service.report_position(
-        user.id, lesson_id, report.position_sec, report.duration_sec
-    )
+    try:
+        return await progress_service.report_position(
+            user.id, lesson_id, report.position_sec, report.duration_sec
+        )
+    except NoResultFound:
+        raise HTTPException(status_code=404, detail="Lesson not found")

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1375,6 +1375,61 @@
         }
       }
     },
+    "/progress/lesson/{lesson_id}/position": {
+      "put": {
+        "tags": [
+          "progress"
+        ],
+        "summary": "Report Lesson Position",
+        "operationId": "report_lesson_position_progress_lesson__lesson_id__position_put",
+        "parameters": [
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lesson Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PositionReport"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LectureProgressData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing token or inactive user."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ping": {
       "get": {
         "tags": [
@@ -2108,6 +2163,28 @@
             },
             "type": "array",
             "title": "Completed Lesson Ids"
+          },
+          "lessons": {
+            "items": {
+              "$ref": "#/components/schemas/LessonProgressItem"
+            },
+            "type": "array",
+            "title": "Lessons"
+          },
+          "resume_lesson_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resume Lesson Id"
+          },
+          "resume_position_sec": {
+            "type": "integer",
+            "title": "Resume Position Sec"
           }
         },
         "type": "object",
@@ -2116,7 +2193,10 @@
           "total_count",
           "percent",
           "next_lesson_id",
-          "completed_lesson_ids"
+          "completed_lesson_ids",
+          "lessons",
+          "resume_lesson_id",
+          "resume_position_sec"
         ],
         "title": "LectureProgressData"
       },
@@ -2273,6 +2353,34 @@
         ],
         "title": "LessonInLecture"
       },
+      "LessonProgressItem": {
+        "properties": {
+          "lesson_id": {
+            "type": "integer",
+            "title": "Lesson Id"
+          },
+          "percent": {
+            "type": "integer",
+            "title": "Percent"
+          },
+          "completed": {
+            "type": "boolean",
+            "title": "Completed"
+          },
+          "last_position_sec": {
+            "type": "integer",
+            "title": "Last Position Sec"
+          }
+        },
+        "type": "object",
+        "required": [
+          "lesson_id",
+          "percent",
+          "completed",
+          "last_position_sec"
+        ],
+        "title": "LessonProgressItem"
+      },
       "OAuth2AuthorizeResponse": {
         "properties": {
           "authorization_url": {
@@ -2358,6 +2466,24 @@
           "end_time"
         ],
         "title": "PlayingGuideStep"
+      },
+      "PositionReport": {
+        "properties": {
+          "position_sec": {
+            "type": "integer",
+            "title": "Position Sec"
+          },
+          "duration_sec": {
+            "type": "integer",
+            "title": "Duration Sec"
+          }
+        },
+        "type": "object",
+        "required": [
+          "position_sec",
+          "duration_sec"
+        ],
+        "title": "PositionReport"
       },
       "SessionDetailResponse": {
         "properties": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1362,6 +1362,9 @@
           "401": {
             "description": "Missing token or inactive user."
           },
+          "404": {
+            "description": "Lesson not found."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1416,6 +1419,9 @@
           },
           "401": {
             "description": "Missing token or inactive user."
+          },
+          "404": {
+            "description": "Lesson not found."
           },
           "422": {
             "description": "Validation Error",

--- a/backend/tests/progress/conftest.py
+++ b/backend/tests/progress/conftest.py
@@ -5,6 +5,8 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import tables as tb
+from app.lecture.repository import LectureRepository
+from app.lecture.service import LectureService
 from app.progress.repository import ProgressRepository
 from app.progress.service import ProgressService
 from tests.containers import TestSessionManager
@@ -16,8 +18,21 @@ def progress_repository(stub_sess_manager: TestSessionManager) -> ProgressReposi
 
 
 @pytest.fixture
-def progress_service(progress_repository: ProgressRepository) -> ProgressService:
-    return ProgressService(repository=progress_repository)
+def lecture_service(stub_sess_manager: TestSessionManager) -> LectureService:
+    return LectureService(
+        repository=LectureRepository(session_manager=stub_sess_manager)
+    )
+
+
+@pytest.fixture
+def progress_service(
+    progress_repository: ProgressRepository,
+    lecture_service: LectureService,
+) -> ProgressService:
+    return ProgressService(
+        repository=progress_repository,
+        lecture_service=lecture_service,
+    )
 
 
 @pytest.fixture

--- a/backend/tests/progress/test_repository.py
+++ b/backend/tests/progress/test_repository.py
@@ -48,3 +48,85 @@ async def test_unmark_removes_progress(
 
     ids = await progress_repository.get_completed_lesson_ids(test_user.id, 600)
     assert ids == []
+
+
+async def test_upsert_position_creates_row(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    row = await progress_repository.upsert_position(test_user.id, 700, 30, 60)
+    assert row.lesson_id == 700
+    assert row.lecture_id == 600
+    assert row.last_position_sec == 30
+    assert row.duration_sec == 60
+    assert row.progress_percent == 50
+    assert row.completed_at is None
+
+
+async def test_upsert_position_is_monotonic(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    await progress_repository.upsert_position(test_user.id, 700, 50, 60)
+    row = await progress_repository.upsert_position(test_user.id, 700, 10, 60)
+    # 위치는 갱신되지만 누적 시청률은 내려가지 않는다
+    assert row.last_position_sec == 10
+    assert row.progress_percent == 83
+
+
+async def test_upsert_position_completes_at_threshold(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    row = await progress_repository.upsert_position(test_user.id, 700, 54, 60)
+    assert row.progress_percent == 90
+    assert row.completed_at is not None
+
+
+async def test_upsert_position_below_threshold_not_completed(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    row = await progress_repository.upsert_position(test_user.id, 700, 53, 60)
+    assert row.progress_percent == 88
+    assert row.completed_at is None
+
+
+async def test_upsert_position_completed_at_stable_after_complete(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    first = await progress_repository.upsert_position(test_user.id, 700, 60, 60)
+    assert first.completed_at is not None
+    completed_at = first.completed_at
+    second = await progress_repository.upsert_position(test_user.id, 700, 5, 60)
+    assert second.completed_at == completed_at
+
+
+async def test_upsert_position_zero_duration_guard(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    row = await progress_repository.upsert_position(test_user.id, 700, 10, 0)
+    assert row.progress_percent == 0
+    assert row.completed_at is None
+
+
+async def test_get_progress_rows_returns_all(
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    await progress_repository.upsert_position(test_user.id, 700, 30, 60)
+    await progress_repository.mark_complete(test_user.id, 701)
+    rows = await progress_repository.get_progress_rows(test_user.id, 600)
+    by_lesson = {r.lesson_id: r for r in rows}
+    assert set(by_lesson) == {700, 701}
+    assert by_lesson[700].completed_at is None
+    assert by_lesson[701].completed_at is not None

--- a/backend/tests/progress/test_service.py
+++ b/backend/tests/progress/test_service.py
@@ -82,3 +82,49 @@ async def test_progress_all_complete_next_is_none(
     assert result.completed_count == 3
     assert result.percent == 100
     assert result.next_lesson_id is None
+    assert result.resume_lesson_id is None
+    assert result.resume_position_sec == 0
+
+
+async def test_progress_per_lesson_aggregation_and_resume(
+    progress_service: ProgressService,
+    progress_repository: ProgressRepository,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    await progress_repository.mark_complete(test_user.id, 700)
+    await progress_repository.upsert_position(test_user.id, 701, 30, 60)
+
+    result = await progress_service.get_lecture_progress(
+        test_user.id, _build_lecture_detail()
+    )
+
+    by_lesson = {item.lesson_id: item for item in result.lessons}
+    assert by_lesson[700].completed is True
+    assert by_lesson[700].percent == 100
+    assert by_lesson[701].completed is False
+    assert by_lesson[701].percent == 50
+    assert by_lesson[701].last_position_sec == 30
+    assert by_lesson[702].completed is False
+    assert by_lesson[702].percent == 0
+    assert by_lesson[702].last_position_sec == 0
+
+    # 헤드라인 percent 는 완료 비율 유지(1/3)
+    assert result.completed_count == 1
+    assert result.percent == 33
+    # resume = 미완료 중 ordering 최소 = 701
+    assert result.resume_lesson_id == 701
+    assert result.resume_position_sec == 30
+
+
+async def test_report_position_returns_progress(
+    progress_service: ProgressService,
+    test_user: tb.User,
+    lecture_with_lessons: tb.Lecture,
+):
+    result = await progress_service.report_position(test_user.id, 701, 30, 60)
+    by_lesson = {item.lesson_id: item for item in result.lessons}
+    assert by_lesson[701].percent == 50
+    assert by_lesson[701].last_position_sec == 30
+    assert result.resume_lesson_id == 700
+    assert result.total_count == 3

--- a/backend/tests/progress/test_tables.py
+++ b/backend/tests/progress/test_tables.py
@@ -73,7 +73,30 @@ async def test_lesson_progress_row_persists(
     saved = result.scalar_one()
     assert saved.lesson_id == 900
     assert saved.lecture_id == progress_lecture.id
-    assert saved.completed_at is not None
+
+
+async def test_lesson_progress_position_fields_default(
+    test_user: tb.User, progress_lecture: tb.Lecture, test_session: AsyncSession
+):
+    progress = tb.LessonProgress(
+        user_id=test_user.id,
+        lesson_id=900,
+        lecture_id=progress_lecture.id,
+        completed_at=None,
+    )
+    async with test_session.begin():
+        test_session.add(progress)
+        await test_session.flush()
+    await test_session.commit()
+
+    result = await test_session.execute(
+        select(tb.LessonProgress).where(tb.LessonProgress.user_id == test_user.id)
+    )
+    saved = result.scalar_one()
+    assert saved.last_position_sec == 0
+    assert saved.duration_sec is None
+    assert saved.progress_percent == 0
+    assert saved.completed_at is None
 
 
 async def test_lesson_progress_unique_user_lesson(

--- a/backend/tests/progress/test_view.py
+++ b/backend/tests/progress/test_view.py
@@ -35,3 +35,33 @@ async def test_mark_complete_is_idempotent(
     response = await authorized_client.post("/progress/lesson/700")
     assert response.status_code == 200
     assert response.json()["completed_count"] == 1
+
+
+async def test_report_position_returns_extended_progress(
+    authorized_client: AsyncClient,
+    lecture_with_lessons: tb.Lecture,
+):
+    response = await authorized_client.put(
+        "/progress/lesson/701/position",
+        json={"position_sec": 30, "duration_sec": 60},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 3
+    assert data["resume_lesson_id"] == 700
+    assert data["resume_position_sec"] == 0
+    by_lesson = {item["lesson_id"]: item for item in data["lessons"]}
+    assert by_lesson[701]["percent"] == 50
+    assert by_lesson[701]["last_position_sec"] == 30
+    assert by_lesson[701]["completed"] is False
+
+
+async def test_report_position_requires_auth(
+    client: AsyncClient,
+    lecture_with_lessons: tb.Lecture,
+):
+    response = await client.put(
+        "/progress/lesson/701/position",
+        json={"position_sec": 30, "duration_sec": 60},
+    )
+    assert response.status_code == 401

--- a/backend/tests/progress/test_view.py
+++ b/backend/tests/progress/test_view.py
@@ -65,3 +65,22 @@ async def test_report_position_requires_auth(
         json={"position_sec": 30, "duration_sec": 60},
     )
     assert response.status_code == 401
+
+
+async def test_report_position_unknown_lesson_returns_404(
+    authorized_client: AsyncClient,
+    lecture_with_lessons: tb.Lecture,
+):
+    response = await authorized_client.put(
+        "/progress/lesson/999999/position",
+        json={"position_sec": 30, "duration_sec": 60},
+    )
+    assert response.status_code == 404
+
+
+async def test_mark_complete_unknown_lesson_returns_404(
+    authorized_client: AsyncClient,
+    lecture_with_lessons: tb.Lecture,
+):
+    response = await authorized_client.post("/progress/lesson/999999")
+    assert response.status_code == 404

--- a/frontend/src/lib/api/client/schemas.gen.ts
+++ b/frontend/src/lib/api/client/schemas.gen.ts
@@ -621,10 +621,32 @@ export const $LectureProgressData = {
             },
             type: 'array',
             title: 'Completed Lesson Ids'
+        },
+        lessons: {
+            items: {
+                '$ref': '#/components/schemas/LessonProgressItem'
+            },
+            type: 'array',
+            title: 'Lessons'
+        },
+        resume_lesson_id: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Resume Lesson Id'
+        },
+        resume_position_sec: {
+            type: 'integer',
+            title: 'Resume Position Sec'
         }
     },
     type: 'object',
-    required: ['completed_count', 'total_count', 'percent', 'next_lesson_id', 'completed_lesson_ids'],
+    required: ['completed_count', 'total_count', 'percent', 'next_lesson_id', 'completed_lesson_ids', 'lessons', 'resume_lesson_id', 'resume_position_sec'],
     title: 'LectureProgressData'
 } as const;
 
@@ -762,6 +784,30 @@ export const $LessonInLecture = {
     title: 'LessonInLecture'
 } as const;
 
+export const $LessonProgressItem = {
+    properties: {
+        lesson_id: {
+            type: 'integer',
+            title: 'Lesson Id'
+        },
+        percent: {
+            type: 'integer',
+            title: 'Percent'
+        },
+        completed: {
+            type: 'boolean',
+            title: 'Completed'
+        },
+        last_position_sec: {
+            type: 'integer',
+            title: 'Last Position Sec'
+        }
+    },
+    type: 'object',
+    required: ['lesson_id', 'percent', 'completed', 'last_position_sec'],
+    title: 'LessonProgressItem'
+} as const;
+
 export const $OAuth2AuthorizeResponse = {
     properties: {
         authorization_url: {
@@ -836,6 +882,22 @@ export const $PlayingGuideStep = {
     type: 'object',
     required: ['step', 'title', 'description', 'start_time', 'end_time'],
     title: 'PlayingGuideStep'
+} as const;
+
+export const $PositionReport = {
+    properties: {
+        position_sec: {
+            type: 'integer',
+            title: 'Position Sec'
+        },
+        duration_sec: {
+            type: 'integer',
+            title: 'Duration Sec'
+        }
+    },
+    type: 'object',
+    required: ['position_sec', 'duration_sec'],
+    title: 'PositionReport'
 } as const;
 
 export const $SessionDetailResponse = {

--- a/frontend/src/lib/api/client/services.gen.ts
+++ b/frontend/src/lib/api/client/services.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { GetArtistsUserArtistsGetResponse, AuthRedisLoginUserAuthLoginPostData, AuthRedisLoginUserAuthLoginPostResponse, AuthRedisLogoutUserAuthLogoutPostResponse, ResetForgotPasswordUserAuthForgotPasswordPostData, ResetForgotPasswordUserAuthForgotPasswordPostResponse, ResetResetPasswordUserAuthResetPasswordPostData, ResetResetPasswordUserAuthResetPasswordPostResponse, OauthGoogleRedisAuthorizeUserOauthGoogleAuthorizeGetData, OauthGoogleRedisAuthorizeUserOauthGoogleAuthorizeGetResponse, OauthGoogleRedisCallbackUserOauthGoogleCallbackGetData, OauthGoogleRedisCallbackUserOauthGoogleCallbackGetResponse, UsersCurrentUserUserMeGetResponse, UsersPatchCurrentUserUserMePatchData, UsersPatchCurrentUserUserMePatchResponse, UsersUserUserIdGetData, UsersUserUserIdGetResponse, UsersPatchUserUserIdPatchData, UsersPatchUserUserIdPatchResponse, UsersDeleteUserUserIdDeleteData, UsersDeleteUserUserIdDeleteResponse, GetLecturesLectureGetData, GetLecturesLectureGetResponse, CreateLectureLecturePostData, CreateLectureLecturePostResponse, GetLectureLectureLectureIdGetData, GetLectureLectureLectureIdGetResponse, UpdateLectureLectureLectureIdPatchData, UpdateLectureLectureLectureIdPatchResponse, GetLessonVideoLessonLessonIdVideoGetData, GetLessonVideoLessonLessonIdVideoGetResponse, UploadLessonVideoLessonLessonIdVideoPostData, UploadLessonVideoLessonLessonIdVideoPostResponse, CreateLessonLessonPostData, CreateLessonLessonPostResponse, UpdateLessonLessonLessonIdPatchData, UpdateLessonLessonLessonIdPatchResponse, UploadLessonSheetmusicLessonLessonIdSheetmusicPostData, UploadLessonSheetmusicLessonLessonIdSheetmusicPostResponse, GetSessionDetailSessionSessionIdGetData, GetSessionDetailSessionSessionIdGetResponse, GetLectureAccessStatusTicketLectureLectureIdGetData, GetLectureAccessStatusTicketLectureLectureIdGetResponse, UseTicketTicketLectureLectureIdPostData, UseTicketTicketLectureLectureIdPostResponse, GetCurationCurationGetResponse, SetCurationCurationSectionPutData, SetCurationCurationSectionPutResponse, MarkLessonCompleteProgressLessonLessonIdPostData, MarkLessonCompleteProgressLessonLessonIdPostResponse, PongPingGetResponse, AuthPongPingAuthGetResponse } from './types.gen';
+import type { GetArtistsUserArtistsGetResponse, AuthRedisLoginUserAuthLoginPostData, AuthRedisLoginUserAuthLoginPostResponse, AuthRedisLogoutUserAuthLogoutPostResponse, ResetForgotPasswordUserAuthForgotPasswordPostData, ResetForgotPasswordUserAuthForgotPasswordPostResponse, ResetResetPasswordUserAuthResetPasswordPostData, ResetResetPasswordUserAuthResetPasswordPostResponse, OauthGoogleRedisAuthorizeUserOauthGoogleAuthorizeGetData, OauthGoogleRedisAuthorizeUserOauthGoogleAuthorizeGetResponse, OauthGoogleRedisCallbackUserOauthGoogleCallbackGetData, OauthGoogleRedisCallbackUserOauthGoogleCallbackGetResponse, UsersCurrentUserUserMeGetResponse, UsersPatchCurrentUserUserMePatchData, UsersPatchCurrentUserUserMePatchResponse, UsersUserUserIdGetData, UsersUserUserIdGetResponse, UsersPatchUserUserIdPatchData, UsersPatchUserUserIdPatchResponse, UsersDeleteUserUserIdDeleteData, UsersDeleteUserUserIdDeleteResponse, GetLecturesLectureGetData, GetLecturesLectureGetResponse, CreateLectureLecturePostData, CreateLectureLecturePostResponse, GetLectureLectureLectureIdGetData, GetLectureLectureLectureIdGetResponse, UpdateLectureLectureLectureIdPatchData, UpdateLectureLectureLectureIdPatchResponse, GetLessonVideoLessonLessonIdVideoGetData, GetLessonVideoLessonLessonIdVideoGetResponse, UploadLessonVideoLessonLessonIdVideoPostData, UploadLessonVideoLessonLessonIdVideoPostResponse, CreateLessonLessonPostData, CreateLessonLessonPostResponse, UpdateLessonLessonLessonIdPatchData, UpdateLessonLessonLessonIdPatchResponse, UploadLessonSheetmusicLessonLessonIdSheetmusicPostData, UploadLessonSheetmusicLessonLessonIdSheetmusicPostResponse, GetSessionDetailSessionSessionIdGetData, GetSessionDetailSessionSessionIdGetResponse, GetLectureAccessStatusTicketLectureLectureIdGetData, GetLectureAccessStatusTicketLectureLectureIdGetResponse, UseTicketTicketLectureLectureIdPostData, UseTicketTicketLectureLectureIdPostResponse, GetCurationCurationGetResponse, SetCurationCurationSectionPutData, SetCurationCurationSectionPutResponse, MarkLessonCompleteProgressLessonLessonIdPostData, MarkLessonCompleteProgressLessonLessonIdPostResponse, ReportLessonPositionProgressLessonLessonIdPositionPutData, ReportLessonPositionProgressLessonLessonIdPositionPutResponse, PongPingGetResponse, AuthPongPingAuthGetResponse } from './types.gen';
 
 /**
  * Get Artists
@@ -503,6 +503,28 @@ export const markLessonCompleteProgressLessonLessonIdPost = (data: MarkLessonCom
     path: {
         lesson_id: data.lessonId
     },
+    errors: {
+        401: 'Missing token or inactive user.',
+        422: 'Validation Error'
+    }
+}); };
+
+/**
+ * Report Lesson Position
+ * @param data The data for the request.
+ * @param data.lessonId
+ * @param data.requestBody
+ * @returns LectureProgressData Successful Response
+ * @throws ApiError
+ */
+export const reportLessonPositionProgressLessonLessonIdPositionPut = (data: ReportLessonPositionProgressLessonLessonIdPositionPutData): CancelablePromise<ReportLessonPositionProgressLessonLessonIdPositionPutResponse> => { return __request(OpenAPI, {
+    method: 'PUT',
+    url: '/progress/lesson/{lesson_id}/position',
+    path: {
+        lesson_id: data.lessonId
+    },
+    body: data.requestBody,
+    mediaType: 'application/json',
     errors: {
         401: 'Missing token or inactive user.',
         422: 'Validation Error'

--- a/frontend/src/lib/api/client/services.gen.ts
+++ b/frontend/src/lib/api/client/services.gen.ts
@@ -505,6 +505,7 @@ export const markLessonCompleteProgressLessonLessonIdPost = (data: MarkLessonCom
     },
     errors: {
         401: 'Missing token or inactive user.',
+        404: 'Lesson not found.',
         422: 'Validation Error'
     }
 }); };
@@ -527,6 +528,7 @@ export const reportLessonPositionProgressLessonLessonIdPositionPut = (data: Repo
     mediaType: 'application/json',
     errors: {
         401: 'Missing token or inactive user.',
+        404: 'Lesson not found.',
         422: 'Validation Error'
     }
 }); };

--- a/frontend/src/lib/api/client/types.gen.ts
+++ b/frontend/src/lib/api/client/types.gen.ts
@@ -135,6 +135,9 @@ export type LectureProgressData = {
     percent: number;
     next_lesson_id: number | null;
     completed_lesson_ids: Array<(number)>;
+    lessons: Array<LessonProgressItem>;
+    resume_lesson_id: number | null;
+    resume_position_sec: number;
 };
 
 export type LessonAdminDetail = {
@@ -165,6 +168,13 @@ export type LessonInLecture = {
     time_updated: string;
 };
 
+export type LessonProgressItem = {
+    lesson_id: number;
+    percent: number;
+    completed: boolean;
+    last_position_sec: number;
+};
+
 export type OAuth2AuthorizeResponse = {
     authorization_url: string;
 };
@@ -183,6 +193,11 @@ export type PlayingGuideStep = {
     start_time: string;
     end_time: string;
     tip?: string | null;
+};
+
+export type PositionReport = {
+    position_sec: number;
+    duration_sec: number;
 };
 
 export type SessionDetailResponse = {
@@ -437,6 +452,13 @@ export type MarkLessonCompleteProgressLessonLessonIdPostData = {
 };
 
 export type MarkLessonCompleteProgressLessonLessonIdPostResponse = LectureProgressData;
+
+export type ReportLessonPositionProgressLessonLessonIdPositionPutData = {
+    lessonId: number;
+    requestBody: PositionReport;
+};
+
+export type ReportLessonPositionProgressLessonLessonIdPositionPutResponse = LectureProgressData;
 
 export type PongPingGetResponse = unknown;
 
@@ -898,6 +920,25 @@ export type $OpenApiTs = {
     '/progress/lesson/{lesson_id}': {
         post: {
             req: MarkLessonCompleteProgressLessonLessonIdPostData;
+            res: {
+                /**
+                 * Successful Response
+                 */
+                200: LectureProgressData;
+                /**
+                 * Missing token or inactive user.
+                 */
+                401: unknown;
+                /**
+                 * Validation Error
+                 */
+                422: HTTPValidationError;
+            };
+        };
+    };
+    '/progress/lesson/{lesson_id}/position': {
+        put: {
+            req: ReportLessonPositionProgressLessonLessonIdPositionPutData;
             res: {
                 /**
                  * Successful Response

--- a/frontend/src/lib/api/client/types.gen.ts
+++ b/frontend/src/lib/api/client/types.gen.ts
@@ -930,6 +930,10 @@ export type $OpenApiTs = {
                  */
                 401: unknown;
                 /**
+                 * Lesson not found.
+                 */
+                404: unknown;
+                /**
                  * Validation Error
                  */
                 422: HTTPValidationError;
@@ -948,6 +952,10 @@ export type $OpenApiTs = {
                  * Missing token or inactive user.
                  */
                 401: unknown;
+                /**
+                 * Lesson not found.
+                 */
+                404: unknown;
                 /**
                  * Validation Error
                  */

--- a/frontend/src/lib/api/progress.ts
+++ b/frontend/src/lib/api/progress.ts
@@ -1,0 +1,16 @@
+import { reportLessonPositionProgressLessonLessonIdPositionPut } from './client/services.gen'
+import type { LectureProgressData } from './client/types.gen'
+
+export async function reportLessonPosition(
+	lessonId: number,
+	positionSec: number,
+	durationSec: number
+): Promise<LectureProgressData> {
+	return await reportLessonPositionProgressLessonLessonIdPositionPut({
+		lessonId,
+		requestBody: {
+			position_sec: Math.round(positionSec),
+			duration_sec: Math.round(durationSec)
+		}
+	})
+}

--- a/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { LessonInLecture } from '$lib/api'
 	import { getLectureStatusMode, type LectureProgress } from '../utils/progress'
-	import { buildMinimap, getFirstLessonId, getResumeLessonId } from '../utils/curriculum'
+	import { getFirstLessonId, getResumeLessonId } from '../utils/curriculum'
 
 	let {
 		sessions,
@@ -24,7 +24,6 @@
 	)
 
 	let mode = $derived(getLectureStatusMode(progress, isAuthenticated, accessible))
-	let cells = $derived(buildMinimap(sortedSessions, progress, isAuthenticated))
 
 	let resumeLessonId = $derived(getResumeLessonId(sortedSessions, progress, isAuthenticated))
 	let firstLessonId = $derived(getFirstLessonId(sortedSessions))
@@ -142,24 +141,6 @@
 				</svg>
 			</span>
 			<span class="text-[13px] text-[#848484]">로그인하면 수강을<br />시작할 수 있어요</span>
-		</div>
-	{/if}
-
-	{#if mode !== 'anonymous'}
-		<div class="mt-[18px] grid grid-cols-6 gap-[6px]" class:opacity-50={mode === 'not-started'}>
-			{#each cells as cell}
-				<span
-					class="h-[9px] rounded-[3px]"
-					class:bg-brand={cell === 'done'}
-					style={cell === 'done'
-						? 'background:#ff5c16'
-						: cell === 'partial'
-							? 'background:#5e3018'
-							: cell === 'current'
-								? `background:transparent;border:1.5px solid ${mode === 'not-started' ? '#3a3a3a' : '#ff5c16'}`
-								: 'background:#1a1a1a'}
-				></span>
-			{/each}
 		</div>
 	{/if}
 

--- a/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
@@ -82,7 +82,14 @@
 					stroke-dashoffset={dashOffset}
 					transform="rotate(-90 63 63)"
 				/>
-				<text x="63" y="60" text-anchor="middle" font-size="25" font-weight="700" fill="#fff">
+				<text
+					x="63"
+					y="60"
+					text-anchor="middle"
+					font-size="25"
+					font-weight="700"
+					fill="#fff"
+				>
 					{percent}%
 				</text>
 				<text x="63" y="80" text-anchor="middle" font-size="11" fill="#848484">완료</text>
@@ -117,9 +124,19 @@
 		>
 			비로그인
 		</span>
-		<div class="flex flex-1 flex-col items-center justify-center gap-[8px] py-[20px] text-center">
-			<span class="flex h-[44px] w-[44px] items-center justify-center rounded-full bg-[#1a1a1a]">
-				<svg class="h-[20px] w-[20px]" viewBox="0 0 24 24" fill="none" stroke="#848484" stroke-width="2">
+		<div
+			class="flex flex-1 flex-col items-center justify-center gap-[8px] py-[20px] text-center"
+		>
+			<span
+				class="flex h-[44px] w-[44px] items-center justify-center rounded-full bg-[#1a1a1a]"
+			>
+				<svg
+					class="h-[20px] w-[20px]"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="#848484"
+					stroke-width="2"
+				>
 					<rect x="5" y="11" width="14" height="9" rx="2" />
 					<path d="M8 11V7a4 4 0 018 0v4" />
 				</svg>
@@ -155,10 +172,14 @@
 		{#if mode === 'anonymous'}
 			로그인하고 시작
 		{:else if mode === 'not-started'}
-			<svg class="h-[17px] w-[17px]" viewBox="0 0 24 24" fill="#fff"><path d="M8 5v14l11-7z" /></svg>
+			<svg class="h-[17px] w-[17px]" viewBox="0 0 24 24" fill="#fff"
+				><path d="M8 5v14l11-7z" /></svg
+			>
 			1강부터 시작하기
 		{:else}
-			<svg class="h-[17px] w-[17px]" viewBox="0 0 24 24" fill="#fff"><path d="M8 5v14l11-7z" /></svg>
+			<svg class="h-[17px] w-[17px]" viewBox="0 0 24 24" fill="#fff"
+				><path d="M8 5v14l11-7z" /></svg
+			>
 			이어서 수강하기
 		{/if}
 	</button>

--- a/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
+++ b/frontend/src/lib/features/lecture/components/LectureProgressPanel.svelte
@@ -136,9 +136,11 @@
 					class:bg-brand={cell === 'done'}
 					style={cell === 'done'
 						? 'background:#ff5c16'
-						: cell === 'current'
-							? `background:transparent;border:1.5px solid ${mode === 'not-started' ? '#3a3a3a' : '#ff5c16'}`
-							: 'background:#1a1a1a'}
+						: cell === 'partial'
+							? 'background:#5e3018'
+							: cell === 'current'
+								? `background:transparent;border:1.5px solid ${mode === 'not-started' ? '#3a3a3a' : '#ff5c16'}`
+								: 'background:#1a1a1a'}
 				></span>
 			{/each}
 		</div>

--- a/frontend/src/lib/features/lecture/utils/curriculum.ts
+++ b/frontend/src/lib/features/lecture/utils/curriculum.ts
@@ -1,7 +1,7 @@
 import type { LectureProgress, SessionState } from './progress'
-import { getSessionState } from './progress'
+import { getSessionState, getLessonPercent } from './progress'
 
-export type MinimapCell = 'done' | 'current' | 'upcoming' | 'locked'
+export type MinimapCell = 'done' | 'current' | 'upcoming' | 'partial' | 'locked'
 
 type OrderedLesson = {
 	id: number
@@ -41,9 +41,13 @@ export function buildMinimap(
 	progress: LectureProgress | null | undefined,
 	isAuthenticated: boolean
 ): MinimapCell[] {
-	return sortByOrdering(lessons).map(
-		(lesson) => STATE_TO_CELL[getSessionState(lesson.id, progress, isAuthenticated)]
-	)
+	return sortByOrdering(lessons).map((lesson) => {
+		const state = getSessionState(lesson.id, progress, isAuthenticated)
+		if (state === 'upcoming' && getLessonPercent(lesson.id, progress) > 0) {
+			return 'partial'
+		}
+		return STATE_TO_CELL[state]
+	})
 }
 
 export function getFirstLessonId(lessons: OrderedLesson[]): number | null {
@@ -56,6 +60,9 @@ export function getResumeLessonId(
 	progress: LectureProgress | null | undefined,
 	isAuthenticated: boolean
 ): number | null {
+	if (isAuthenticated && progress?.resume_lesson_id != null) {
+		return progress.resume_lesson_id
+	}
 	if (isAuthenticated && progress?.next_lesson_id != null) {
 		return progress.next_lesson_id
 	}

--- a/frontend/src/lib/features/lecture/utils/curriculum.ts
+++ b/frontend/src/lib/features/lecture/utils/curriculum.ts
@@ -1,7 +1,4 @@
-import type { LectureProgress, SessionState } from './progress'
-import { getSessionState, getLessonPercent } from './progress'
-
-export type MinimapCell = 'done' | 'current' | 'upcoming' | 'partial' | 'locked'
+import type { LectureProgress } from './progress'
 
 type OrderedLesson = {
 	id: number
@@ -27,27 +24,6 @@ export function getDifficultyLabel(tags: unknown[] | null | undefined): string {
 		if (label) return label
 	}
 	return '-'
-}
-
-const STATE_TO_CELL: Record<SessionState, MinimapCell> = {
-	completed: 'done',
-	current: 'current',
-	upcoming: 'upcoming',
-	locked: 'locked'
-}
-
-export function buildMinimap(
-	lessons: OrderedLesson[],
-	progress: LectureProgress | null | undefined,
-	isAuthenticated: boolean
-): MinimapCell[] {
-	return sortByOrdering(lessons).map((lesson) => {
-		const state = getSessionState(lesson.id, progress, isAuthenticated)
-		if (state === 'upcoming' && getLessonPercent(lesson.id, progress) > 0) {
-			return 'partial'
-		}
-		return STATE_TO_CELL[state]
-	})
 }
 
 export function getFirstLessonId(lessons: OrderedLesson[]): number | null {

--- a/frontend/src/lib/features/lecture/utils/progress.ts
+++ b/frontend/src/lib/features/lecture/utils/progress.ts
@@ -44,13 +44,6 @@ function findLessonItem(lessonId: number, progress: LectureProgress | null | und
 	return progress?.lessons?.find((l) => l.lesson_id === lessonId) ?? null
 }
 
-export function getLessonPercent(
-	lessonId: number,
-	progress: LectureProgress | null | undefined
-): number {
-	return findLessonItem(lessonId, progress)?.percent ?? 0
-}
-
 export function getLessonLastPosition(
 	lessonId: number,
 	progress: LectureProgress | null | undefined

--- a/frontend/src/lib/features/lecture/utils/progress.ts
+++ b/frontend/src/lib/features/lecture/utils/progress.ts
@@ -39,14 +39,3 @@ export function getSessionState(
 	}
 	return 'upcoming'
 }
-
-function findLessonItem(lessonId: number, progress: LectureProgress | null | undefined) {
-	return progress?.lessons?.find((l) => l.lesson_id === lessonId) ?? null
-}
-
-export function getLessonLastPosition(
-	lessonId: number,
-	progress: LectureProgress | null | undefined
-): number {
-	return findLessonItem(lessonId, progress)?.last_position_sec ?? 0
-}

--- a/frontend/src/lib/features/lecture/utils/progress.ts
+++ b/frontend/src/lib/features/lecture/utils/progress.ts
@@ -39,3 +39,21 @@ export function getSessionState(
 	}
 	return 'upcoming'
 }
+
+function findLessonItem(lessonId: number, progress: LectureProgress | null | undefined) {
+	return progress?.lessons?.find((l) => l.lesson_id === lessonId) ?? null
+}
+
+export function getLessonPercent(
+	lessonId: number,
+	progress: LectureProgress | null | undefined
+): number {
+	return findLessonItem(lessonId, progress)?.percent ?? 0
+}
+
+export function getLessonLastPosition(
+	lessonId: number,
+	progress: LectureProgress | null | undefined
+): number {
+	return findLessonItem(lessonId, progress)?.last_position_sec ?? 0
+}

--- a/frontend/src/lib/features/session/components/SubtitleRoller.svelte
+++ b/frontend/src/lib/features/session/components/SubtitleRoller.svelte
@@ -72,7 +72,11 @@
 </script>
 
 <script lang="ts">
+	import { onDestroy } from 'svelte'
 	import { formatSubtitleTimestamp } from '../utils'
+
+	/** 휠 탐색이 멈춘 뒤 이 시간(ms)이 지나면 수동 인덱스를 해제하고 재생 시간 추적으로 복귀 */
+	const WHEEL_RELEASE_MS = 2000
 
 	let {
 		subtitles,
@@ -91,6 +95,7 @@
 	let activeIndex = $derived(resolveActiveIndex(manualIndex, subtitles, currentTime * 1000))
 
 	let wheelLock = false
+	let wheelReleaseTimer: ReturnType<typeof setTimeout> | undefined
 	let previousActiveIndex = -1
 
 	$effect(() => {
@@ -114,13 +119,21 @@
 		setTimeout(() => (wheelLock = false), 90)
 		const base = activeIndex < 0 ? 0 : activeIndex
 		manualIndex = computeWheelIndex(base, event.deltaY, subtitles.length)
+		// 휠이 멈춘 뒤 일정 시간이 지나면 수동 인덱스를 해제해 재생 시간 추적으로 복귀시킨다.
+		clearTimeout(wheelReleaseTimer)
+		wheelReleaseTimer = setTimeout(() => (manualIndex = null), WHEEL_RELEASE_MS)
 	}
 
 	function toggleExpanded() {
 		expanded = !expanded
 		// 펼치면 전체 탐색 모드 → 휠 탐색 상태를 해제해 재생 위치에 다시 동기화한다.
-		if (expanded) manualIndex = null
+		if (expanded) {
+			clearTimeout(wheelReleaseTimer)
+			manualIndex = null
+		}
 	}
+
+	onDestroy(() => clearTimeout(wheelReleaseTimer))
 </script>
 
 <div

--- a/frontend/src/lib/features/session/index.ts
+++ b/frontend/src/lib/features/session/index.ts
@@ -11,4 +11,5 @@ export { default as NextSessionCountdown } from './components/NextSessionCountdo
 export * from './types'
 export * from './utils'
 export * from './services'
+export * from './progress-report'
 export * from './splash'

--- a/frontend/src/lib/features/session/progress-report.ts
+++ b/frontend/src/lib/features/session/progress-report.ts
@@ -1,0 +1,70 @@
+/**
+ * 시청 위치 리포팅 판정 (순수 함수 모듈, side-effect 없음)
+ *
+ * Svelte $effect 무한루프(effect_update_depth_exceeded, #125) 회귀 방지를 위해
+ * 판정 로직을 순수함수로 분리한다. effect 안에서 같은 $state 를 쓰고-읽지 않도록
+ * 다음 상태를 반환하면 호출부가 비반응 변수에 저장한다.
+ */
+
+const HEARTBEAT_INTERVAL_MS = 10_000
+const THRESHOLD90 = 0.9
+
+export interface ReportState {
+	/** 마지막 report 시각(ms epoch) */
+	lastReportedAt: number
+	/** 90% 강제발화 1회성 플래그 */
+	fired90: boolean
+}
+
+export interface PositionSample {
+	currentTime: number
+	duration: number
+	now: number
+}
+
+export interface ReportDecision extends ReportState {
+	shouldReport: boolean
+	reason: 'heartbeat' | 'threshold90' | 'none'
+}
+
+export function createReportState(): ReportState {
+	return { lastReportedAt: 0, fired90: false }
+}
+
+/**
+ * 시청 비율(0~100 정수). duration 가드 포함.
+ */
+export function computePercent(positionSec: number, durationSec: number): number {
+	if (durationSec <= 0) return 0
+	const ratio = positionSec / durationSec
+	return Math.min(100, Math.max(0, Math.round(ratio * 100)))
+}
+
+/**
+ * 현재 위치 샘플로 리포팅 여부와 다음 상태를 계산한다.
+ * - 90% 강제발화: duration>0 && currentTime >= duration*0.9 && !fired90 → throttle 무시 1회
+ * - heartbeat: now - lastReportedAt >= 10초
+ */
+export function evaluatePositionReport(state: ReportState, sample: PositionSample): ReportDecision {
+	const { currentTime, duration, now } = sample
+
+	if (duration <= 0) {
+		return { ...state, shouldReport: false, reason: 'none' }
+	}
+
+	const crossed90 = currentTime >= duration * THRESHOLD90
+	if (crossed90 && !state.fired90) {
+		return { lastReportedAt: now, fired90: true, shouldReport: true, reason: 'threshold90' }
+	}
+
+	if (now - state.lastReportedAt >= HEARTBEAT_INTERVAL_MS) {
+		return {
+			lastReportedAt: now,
+			fired90: state.fired90,
+			shouldReport: true,
+			reason: 'heartbeat'
+		}
+	}
+
+	return { ...state, shouldReport: false, reason: 'none' }
+}

--- a/frontend/src/lib/features/session/progress-report.ts
+++ b/frontend/src/lib/features/session/progress-report.ts
@@ -68,3 +68,28 @@ export function evaluatePositionReport(state: ReportState, sample: PositionSampl
 
 	return { ...state, shouldReport: false, reason: 'none' }
 }
+
+export interface PositionBeacon {
+	url: string
+	blob: Blob
+}
+
+/**
+ * unload 시 navigator.sendBeacon 으로 전송할 최종 위치 payload 생성.
+ */
+export function buildPositionBeacon(
+	baseUrl: string,
+	lessonId: number,
+	positionSec: number,
+	durationSec: number
+): PositionBeacon {
+	const base = baseUrl.replace(/\/+$/, '')
+	const body = JSON.stringify({
+		position_sec: Math.round(positionSec),
+		duration_sec: Math.round(durationSec)
+	})
+	return {
+		url: `${base}/progress/lesson/${lessonId}/position`,
+		blob: new Blob([body], { type: 'application/json' })
+	}
+}

--- a/frontend/src/lib/features/session/services.ts
+++ b/frontend/src/lib/features/session/services.ts
@@ -1,7 +1,25 @@
 import { fetchSessionDetail } from '$lib/api/session'
+import { reportLessonPosition as apiReportLessonPosition } from '$lib/api/progress'
 import { toSessionDetailData, type SessionDetailData } from './types'
 
 export async function loadSessionDetail(sessionId: number): Promise<SessionDetailData> {
 	const response = await fetchSessionDetail(sessionId)
 	return toSessionDetailData(response)
+}
+
+/**
+ * 시청 위치 리포팅 (fire-and-forget). 에러는 콘솔에만 남기고 throw 하지 않는다.
+ * @returns 갱신된 LectureProgressData (실패 시 null)
+ */
+export async function reportLessonPosition(
+	lessonId: number,
+	positionSec: number,
+	durationSec: number
+) {
+	try {
+		return await apiReportLessonPosition(lessonId, positionSec, durationSec)
+	} catch (e) {
+		console.error('[session] 위치 리포팅 실패', e)
+		return null
+	}
 }

--- a/frontend/src/lib/features/session/services.ts
+++ b/frontend/src/lib/features/session/services.ts
@@ -1,5 +1,6 @@
 import { fetchSessionDetail } from '$lib/api/session'
 import { reportLessonPosition as apiReportLessonPosition } from '$lib/api/progress'
+import { getLectureLectureLectureIdGet } from '$lib/api/client/services.gen'
 import { toSessionDetailData, type SessionDetailData } from './types'
 
 export async function loadSessionDetail(sessionId: number): Promise<SessionDetailData> {
@@ -21,5 +22,23 @@ export async function reportLessonPosition(
 	} catch (e) {
 		console.error('[session] 위치 리포팅 실패', e)
 		return null
+	}
+}
+
+/**
+ * 이어보기 위치 조회. 렉처 진행도의 lessons[]에서 해당 lesson_id의
+ * last_position_sec 를 추출한다. 실패/미존재 시 0(처음부터).
+ */
+export async function fetchLessonResumePosition(
+	lectureId: number,
+	lessonId: number
+): Promise<number> {
+	try {
+		const res = await getLectureLectureLectureIdGet({ lectureId })
+		const item = res.data.progress?.lessons?.find((l) => l.lesson_id === lessonId)
+		return item?.last_position_sec ?? 0
+	} catch (e) {
+		console.error('[session] 이어보기 위치 조회 실패', e)
+		return 0
 	}
 }

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -232,6 +232,12 @@
 			goto(`/session/${session.nextSessionId}`)
 		}
 	}
+
+	function goToLecture() {
+		if (session?.lectureId != null) {
+			goto(`/lecture/${session.lectureId}`)
+		}
+	}
 </script>
 
 <main data-testid="session-detail-page" class="min-h-screen bg-[#0c0c0c] pt-[73px] flex flex-col">
@@ -245,6 +251,24 @@
 				<div class="text-red-400 text-lg">{error}</div>
 			</div>
 		{:else if session}
+			<!-- 강의로 돌아가기 -->
+			<button
+				type="button"
+				data-testid="back-to-lecture"
+				onclick={goToLecture}
+				class="group mb-3 inline-flex items-center gap-1.5 text-sm text-[#999] hover:text-white transition-colors"
+			>
+				<svg
+					class="w-4 h-4 transition-transform group-hover:-translate-x-0.5"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+				</svg>
+				<span class="truncate max-w-[52ch]">{session.lectureTitle}</span>
+			</button>
+
 			<!-- 심플 헤더 -->
 			<div class="flex items-end justify-between gap-4 mb-5">
 				<h1 data-testid="session-title" class="text-2xl font-bold leading-tight text-white">

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import Hls from 'hls.js'
+	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import { waitForApiInit } from '$lib/api/config'
+	import { OpenAPI } from '$lib/api/client'
 	import {
 		VideoPlayer,
 		SubtitleRoller,
@@ -9,6 +11,11 @@
 		SessionLoadingSplash,
 		NextSessionCountdown,
 		loadSessionDetail,
+		reportLessonPosition,
+		fetchLessonResumePosition,
+		evaluatePositionReport,
+		createReportState,
+		buildPositionBeacon,
 		MIN_SPLASH_MS,
 		PRELOAD_TIMEOUT_MS,
 		areResourcesReady,
@@ -17,7 +24,8 @@
 		selectPreloadStrategy,
 		shouldShowCountdown,
 		type SessionDetailData,
-		type SeekRequest
+		type SeekRequest,
+		type ReportState
 	} from '$lib/features/session'
 
 	let { data } = $props()
@@ -36,6 +44,76 @@
 	function handleSeekRequest(timeSec: number) {
 		seekRequest = { time: timeSec, version: (seekRequest?.version ?? 0) + 1 }
 	}
+
+	// --- 위치 리포팅 (비반응 상태: effect 자기참조 회귀 #125 방지) ---
+	let reportState: ReportState = createReportState()
+	let lastPosition = 0
+	let lastDuration = 0
+
+	function resetReporting() {
+		reportState = createReportState()
+		lastPosition = 0
+		lastDuration = 0
+	}
+
+	function sendReport(positionSec: number, durationSec: number) {
+		if (!session || durationSec <= 0) return
+		void reportLessonPosition(session.id, positionSec, durationSec)
+	}
+
+	function handlePositionUpdate(time: number, duration: number) {
+		currentTime = time
+		lastPosition = time
+		lastDuration = duration
+		const decision = evaluatePositionReport(reportState, {
+			currentTime: time,
+			duration,
+			now: Date.now()
+		})
+		reportState = { lastReportedAt: decision.lastReportedAt, fired90: decision.fired90 }
+		if (decision.shouldReport) {
+			sendReport(time, duration)
+		}
+	}
+
+	function flushPosition(viaBeacon: boolean) {
+		if (!session || lastDuration <= 0) return
+		if (viaBeacon && typeof navigator !== 'undefined') {
+			// PUT 전용 엔드포인트라 sendBeacon(POST) 대신 fetch keepalive 사용
+			const beacon = buildPositionBeacon(OpenAPI.BASE, session.id, lastPosition, lastDuration)
+			void fetch(beacon.url, {
+				method: 'PUT',
+				body: beacon.blob,
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				keepalive: true
+			}).catch(() => {})
+			return
+		}
+		sendReport(lastPosition, lastDuration)
+	}
+
+	async function applyResumeSeek(loaded: SessionDetailData) {
+		const pos = await fetchLessonResumePosition(loaded.lectureId, loaded.id)
+		if (pos > 0 && session?.id === loaded.id) {
+			handleSeekRequest(pos)
+		}
+	}
+
+	function handleVisibilityChange() {
+		if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+			flushPosition(true)
+		}
+	}
+
+	onMount(() => {
+		if (typeof document === 'undefined') return
+		document.addEventListener('visibilitychange', handleVisibilityChange)
+		window.addEventListener('beforeunload', () => flushPosition(true))
+		return () => {
+			document.removeEventListener('visibilitychange', handleVisibilityChange)
+		}
+	})
 
 	let currentRequestId = 0
 	let minTimer: ReturnType<typeof setTimeout> | undefined
@@ -99,6 +177,8 @@
 		minElapsed = false
 		videoPreloaded = false
 		showCountdown = false
+		seekRequest = undefined
+		resetReporting()
 
 		minTimer = setTimeout(() => {
 			if (requestId === currentRequestId) minElapsed = true
@@ -110,6 +190,7 @@
 			if (requestId !== currentRequestId) return
 			session = result
 			startVideoPreload(result.videoUrl, requestId)
+			void applyResumeSeek(result)
 		} catch (e) {
 			if (requestId !== currentRequestId) return
 			error = e instanceof Error ? e.message : '세션을 불러올 수 없습니다'
@@ -186,9 +267,12 @@
 						<VideoPlayer
 							src={session.videoUrl}
 							seekTo={seekRequest}
-							ontimeupdate={(e) => (currentTime = e.currentTime)}
+							ontimeupdate={(e) => handlePositionUpdate(e.currentTime, e.duration)}
+							onpause={() => flushPosition(false)}
 							onended={() => {
-								if (shouldShowCountdown(session?.nextSessionId)) showCountdown = true
+								flushPosition(false)
+								if (shouldShowCountdown(session?.nextSessionId))
+									showCountdown = true
 							}}
 						/>
 						{#if showCountdown && session.nextSessionId}

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -252,7 +252,7 @@
 				</h1>
 				<div data-testid="session-progress" class="text-sm font-medium shrink-0">
 					<span class="text-brand-primary"
-						>{String(session.lectureOrdering).padStart(2, '0')}</span
+						>{String(session.lectureOrdering + 1).padStart(2, '0')}</span
 					>
 					<span class="text-[#666] mx-1.5">/</span>
 					<span class="text-[#ddd]">{String(session.totalSessions).padStart(2, '0')}</span
@@ -336,7 +336,7 @@
 
 				<div class="text-white font-medium">
 					<span class="text-brand-primary"
-						>{String(session.lectureOrdering).padStart(2, '0')}</span
+						>{String(session.lectureOrdering + 1).padStart(2, '0')}</span
 					>
 					<span class="text-[#666] mx-2">/</span>
 					<span>{String(session.totalSessions).padStart(2, '0')}</span>

--- a/frontend/tests/unit/api/progress.test.ts
+++ b/frontend/tests/unit/api/progress.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('$lib/api/client/services.gen', () => ({
+	reportLessonPositionProgressLessonLessonIdPositionPut: vi.fn()
+}))
+
+describe('Progress API Service', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('reportLessonPosition', () => {
+		it('lessonId/position/duration으로 PUT position을 호출한다', async () => {
+			const { reportLessonPositionProgressLessonLessonIdPositionPut } = await import(
+				'$lib/api/client/services.gen'
+			)
+			const { reportLessonPosition } = await import('$lib/api/progress')
+
+			const mockResponse = { percent: 50 }
+			vi.mocked(reportLessonPositionProgressLessonLessonIdPositionPut).mockResolvedValue(
+				mockResponse as any
+			)
+
+			const result = await reportLessonPosition(700, 45, 90)
+
+			expect(reportLessonPositionProgressLessonLessonIdPositionPut).toHaveBeenCalledWith({
+				lessonId: 700,
+				requestBody: { position_sec: 45, duration_sec: 90 }
+			})
+			expect(result).toEqual(mockResponse)
+		})
+
+		it('position/duration을 정수로 반올림하여 전송한다', async () => {
+			const { reportLessonPositionProgressLessonLessonIdPositionPut } = await import(
+				'$lib/api/client/services.gen'
+			)
+			const { reportLessonPosition } = await import('$lib/api/progress')
+
+			vi.mocked(reportLessonPositionProgressLessonLessonIdPositionPut).mockResolvedValue({} as any)
+
+			await reportLessonPosition(700, 45.7, 90.2)
+
+			expect(reportLessonPositionProgressLessonLessonIdPositionPut).toHaveBeenCalledWith({
+				lessonId: 700,
+				requestBody: { position_sec: 46, duration_sec: 90 }
+			})
+		})
+	})
+})

--- a/frontend/tests/unit/api/progress.test.ts
+++ b/frontend/tests/unit/api/progress.test.ts
@@ -11,9 +11,8 @@ describe('Progress API Service', () => {
 
 	describe('reportLessonPosition', () => {
 		it('lessonId/position/duration으로 PUT position을 호출한다', async () => {
-			const { reportLessonPositionProgressLessonLessonIdPositionPut } = await import(
-				'$lib/api/client/services.gen'
-			)
+			const { reportLessonPositionProgressLessonLessonIdPositionPut } =
+				await import('$lib/api/client/services.gen')
 			const { reportLessonPosition } = await import('$lib/api/progress')
 
 			const mockResponse = { percent: 50 }
@@ -31,12 +30,13 @@ describe('Progress API Service', () => {
 		})
 
 		it('position/duration을 정수로 반올림하여 전송한다', async () => {
-			const { reportLessonPositionProgressLessonLessonIdPositionPut } = await import(
-				'$lib/api/client/services.gen'
-			)
+			const { reportLessonPositionProgressLessonLessonIdPositionPut } =
+				await import('$lib/api/client/services.gen')
 			const { reportLessonPosition } = await import('$lib/api/progress')
 
-			vi.mocked(reportLessonPositionProgressLessonLessonIdPositionPut).mockResolvedValue({} as any)
+			vi.mocked(reportLessonPositionProgressLessonLessonIdPositionPut).mockResolvedValue(
+				{} as any
+			)
 
 			await reportLessonPosition(700, 45.7, 90.2)
 

--- a/frontend/tests/unit/features/lecture/curriculum.test.ts
+++ b/frontend/tests/unit/features/lecture/curriculum.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
 	formatTotalLength,
 	getDifficultyLabel,
-	buildMinimap,
 	getResumeLessonId,
-	getFirstLessonId,
-	type MinimapCell
+	getFirstLessonId
 } from '$lib/features/lecture/utils/curriculum'
 import type { LectureProgress } from '$lib/features/lecture/utils/progress'
 
@@ -57,56 +55,6 @@ describe('getDifficultyLabel', () => {
 	it('난이도 태그가 없으면 대시', () => {
 		expect(getDifficultyLabel(['해석버전'])).toBe('-')
 		expect(getDifficultyLabel(null)).toBe('-')
-	})
-})
-
-describe('buildMinimap', () => {
-	it('순서대로 done/current/upcoming 셀을 만든다', () => {
-		const p = progress({ completed_lesson_ids: [700], next_lesson_id: 701, completed_count: 1 })
-		const cells: MinimapCell[] = buildMinimap(lessons, p, true)
-		expect(cells).toEqual(['done', 'current', 'upcoming'])
-	})
-
-	it('비로그인이면 모두 locked', () => {
-		const cells = buildMinimap(lessons, null, false)
-		expect(cells).toEqual(['locked', 'locked', 'locked'])
-	})
-
-	it('미수강이면 1강이 current, 나머지 upcoming', () => {
-		const p = progress({ next_lesson_id: 700, completed_count: 0 })
-		const cells = buildMinimap(lessons, p, true)
-		expect(cells).toEqual(['current', 'upcoming', 'upcoming'])
-	})
-
-	it('완료 아님 + percent>0 인 lesson은 partial', () => {
-		const p = progress({
-			next_lesson_id: 700,
-			completed_count: 0,
-			lessons: [{ lesson_id: 701, percent: 40, completed: false, last_position_sec: 50 }]
-		})
-		const cells = buildMinimap(lessons, p, true)
-		expect(cells).toEqual(['current', 'partial', 'upcoming'])
-	})
-
-	it('완료 셀은 percent>0 이어도 done이 우선', () => {
-		const p = progress({
-			completed_lesson_ids: [700],
-			next_lesson_id: 701,
-			completed_count: 1,
-			lessons: [{ lesson_id: 700, percent: 100, completed: true, last_position_sec: 90 }]
-		})
-		const cells = buildMinimap(lessons, p, true)
-		expect(cells).toEqual(['done', 'current', 'upcoming'])
-	})
-
-	it('current 셀은 percent>0 이어도 current가 우선', () => {
-		const p = progress({
-			next_lesson_id: 700,
-			completed_count: 0,
-			lessons: [{ lesson_id: 700, percent: 30, completed: false, last_position_sec: 20 }]
-		})
-		const cells = buildMinimap(lessons, p, true)
-		expect(cells).toEqual(['current', 'upcoming', 'upcoming'])
 	})
 })
 

--- a/frontend/tests/unit/features/lecture/curriculum.test.ts
+++ b/frontend/tests/unit/features/lecture/curriculum.test.ts
@@ -15,6 +15,9 @@ const progress = (overrides: Partial<LectureProgress> = {}): LectureProgress => 
 	percent: 0,
 	next_lesson_id: 700,
 	completed_lesson_ids: [],
+	lessons: [],
+	resume_lesson_id: null,
+	resume_position_sec: 0,
 	...overrides
 })
 
@@ -73,6 +76,49 @@ describe('buildMinimap', () => {
 		const p = progress({ next_lesson_id: 700, completed_count: 0 })
 		const cells = buildMinimap(lessons, p, true)
 		expect(cells).toEqual(['current', 'upcoming', 'upcoming'])
+	})
+
+	it('완료 아님 + percent>0 인 lesson은 partial', () => {
+		const p = progress({
+			next_lesson_id: 700,
+			completed_count: 0,
+			lessons: [{ lesson_id: 701, percent: 40, completed: false, last_position_sec: 50 }]
+		})
+		const cells = buildMinimap(lessons, p, true)
+		expect(cells).toEqual(['current', 'partial', 'upcoming'])
+	})
+
+	it('완료 셀은 percent>0 이어도 done이 우선', () => {
+		const p = progress({
+			completed_lesson_ids: [700],
+			next_lesson_id: 701,
+			completed_count: 1,
+			lessons: [{ lesson_id: 700, percent: 100, completed: true, last_position_sec: 90 }]
+		})
+		const cells = buildMinimap(lessons, p, true)
+		expect(cells).toEqual(['done', 'current', 'upcoming'])
+	})
+
+	it('current 셀은 percent>0 이어도 current가 우선', () => {
+		const p = progress({
+			next_lesson_id: 700,
+			completed_count: 0,
+			lessons: [{ lesson_id: 700, percent: 30, completed: false, last_position_sec: 20 }]
+		})
+		const cells = buildMinimap(lessons, p, true)
+		expect(cells).toEqual(['current', 'upcoming', 'upcoming'])
+	})
+})
+
+describe('getResumeLessonId - 서버 resume 우선', () => {
+	it('서버 resume_lesson_id가 있으면 우선 사용', () => {
+		const p = progress({ next_lesson_id: 700, resume_lesson_id: 702 })
+		expect(getResumeLessonId(lessons, p, true)).toBe(702)
+	})
+
+	it('서버 resume_lesson_id가 null이면 next_lesson_id 폴백', () => {
+		const p = progress({ next_lesson_id: 701, resume_lesson_id: null })
+		expect(getResumeLessonId(lessons, p, true)).toBe(701)
 	})
 })
 

--- a/frontend/tests/unit/features/lecture/progress.test.ts
+++ b/frontend/tests/unit/features/lecture/progress.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
 	getLectureStatusMode,
 	getSessionState,
-	getLessonPercent,
 	getLessonLastPosition,
 	type LectureProgress
 } from '$lib/features/lecture/utils/progress'
@@ -90,24 +89,6 @@ describe('getSessionState', () => {
 
 	it('비로그인이면 locked', () => {
 		expect(getSessionState(700, null, false)).toBe('locked')
-	})
-})
-
-describe('getLessonPercent', () => {
-	it('lessons[]에서 lesson_id 매칭 percent를 반환', () => {
-		const p = progress({
-			lessons: [{ lesson_id: 700, percent: 42, completed: false, last_position_sec: 30 }]
-		})
-		expect(getLessonPercent(700, p)).toBe(42)
-	})
-
-	it('매칭 없으면 0', () => {
-		const p = progress({ lessons: [] })
-		expect(getLessonPercent(999, p)).toBe(0)
-	})
-
-	it('progress 없으면 0', () => {
-		expect(getLessonPercent(700, null)).toBe(0)
 	})
 })
 

--- a/frontend/tests/unit/features/lecture/progress.test.ts
+++ b/frontend/tests/unit/features/lecture/progress.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
 	getLectureStatusMode,
 	getSessionState,
+	getLessonPercent,
+	getLessonLastPosition,
 	type LectureProgress
 } from '$lib/features/lecture/utils/progress'
 
@@ -11,6 +13,9 @@ const progress = (overrides: Partial<LectureProgress> = {}): LectureProgress => 
 	percent: 0,
 	next_lesson_id: 700,
 	completed_lesson_ids: [],
+	lessons: [],
+	resume_lesson_id: null,
+	resume_position_sec: 0,
 	...overrides
 })
 
@@ -79,5 +84,37 @@ describe('getSessionState', () => {
 
 	it('비로그인이면 locked', () => {
 		expect(getSessionState(700, null, false)).toBe('locked')
+	})
+})
+
+describe('getLessonPercent', () => {
+	it('lessons[]에서 lesson_id 매칭 percent를 반환', () => {
+		const p = progress({
+			lessons: [{ lesson_id: 700, percent: 42, completed: false, last_position_sec: 30 }]
+		})
+		expect(getLessonPercent(700, p)).toBe(42)
+	})
+
+	it('매칭 없으면 0', () => {
+		const p = progress({ lessons: [] })
+		expect(getLessonPercent(999, p)).toBe(0)
+	})
+
+	it('progress 없으면 0', () => {
+		expect(getLessonPercent(700, null)).toBe(0)
+	})
+})
+
+describe('getLessonLastPosition', () => {
+	it('lessons[]에서 lesson_id 매칭 last_position_sec를 반환', () => {
+		const p = progress({
+			lessons: [{ lesson_id: 700, percent: 42, completed: false, last_position_sec: 30 }]
+		})
+		expect(getLessonLastPosition(700, p)).toBe(30)
+	})
+
+	it('매칭 없으면 0', () => {
+		expect(getLessonLastPosition(999, progress())).toBe(0)
+		expect(getLessonLastPosition(700, null)).toBe(0)
 	})
 })

--- a/frontend/tests/unit/features/lecture/progress.test.ts
+++ b/frontend/tests/unit/features/lecture/progress.test.ts
@@ -40,19 +40,21 @@ describe('getLectureStatusMode', () => {
 	})
 
 	it('accessible=true 이고 completed=0 이면 in-progress (0% 활성)', () => {
-		expect(getLectureStatusMode(progress({ completed_count: 0 }), true, true)).toBe('in-progress')
+		expect(getLectureStatusMode(progress({ completed_count: 0 }), true, true)).toBe(
+			'in-progress'
+		)
 	})
 
 	it('accessible=false 이면 completed>0 이어도 not-started (티켓 미사용 우선)', () => {
-		expect(getLectureStatusMode(progress({ completed_count: 2, percent: 66 }), true, false)).toBe(
-			'not-started'
-		)
+		expect(
+			getLectureStatusMode(progress({ completed_count: 2, percent: 66 }), true, false)
+		).toBe('not-started')
 	})
 
 	it('accessible=true 이고 completed>0 이면 in-progress', () => {
-		expect(getLectureStatusMode(progress({ completed_count: 1, percent: 33 }), true, true)).toBe(
-			'in-progress'
-		)
+		expect(
+			getLectureStatusMode(progress({ completed_count: 1, percent: 33 }), true, true)
+		).toBe('in-progress')
 	})
 
 	it('accessible 생략 시 기존 휴리스틱 유지', () => {
@@ -61,8 +63,12 @@ describe('getLectureStatusMode', () => {
 	})
 
 	it('비인증이면 accessible 값과 무관하게 anonymous', () => {
-		expect(getLectureStatusMode(progress({ completed_count: 1 }), false, true)).toBe('anonymous')
-		expect(getLectureStatusMode(progress({ completed_count: 1 }), false, false)).toBe('anonymous')
+		expect(getLectureStatusMode(progress({ completed_count: 1 }), false, true)).toBe(
+			'anonymous'
+		)
+		expect(getLectureStatusMode(progress({ completed_count: 1 }), false, false)).toBe(
+			'anonymous'
+		)
 	})
 })
 

--- a/frontend/tests/unit/features/lecture/progress.test.ts
+++ b/frontend/tests/unit/features/lecture/progress.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
 	getLectureStatusMode,
 	getSessionState,
-	getLessonLastPosition,
 	type LectureProgress
 } from '$lib/features/lecture/utils/progress'
 
@@ -89,19 +88,5 @@ describe('getSessionState', () => {
 
 	it('비로그인이면 locked', () => {
 		expect(getSessionState(700, null, false)).toBe('locked')
-	})
-})
-
-describe('getLessonLastPosition', () => {
-	it('lessons[]에서 lesson_id 매칭 last_position_sec를 반환', () => {
-		const p = progress({
-			lessons: [{ lesson_id: 700, percent: 42, completed: false, last_position_sec: 30 }]
-		})
-		expect(getLessonLastPosition(700, p)).toBe(30)
-	})
-
-	it('매칭 없으면 0', () => {
-		expect(getLessonLastPosition(999, progress())).toBe(0)
-		expect(getLessonLastPosition(700, null)).toBe(0)
 	})
 })

--- a/frontend/tests/unit/features/session/progress-report.test.ts
+++ b/frontend/tests/unit/features/session/progress-report.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+	evaluatePositionReport,
+	createReportState,
+	computePercent,
+	type ReportState
+} from '$lib/features/session/progress-report'
+
+const state = (overrides: Partial<ReportState> = {}): ReportState => ({
+	lastReportedAt: 0,
+	fired90: false,
+	...overrides
+})
+
+describe('computePercent', () => {
+	it('position/duration 비율을 0~100 정수로 반환', () => {
+		expect(computePercent(45, 90)).toBe(50)
+		expect(computePercent(90, 90)).toBe(100)
+	})
+
+	it('duration이 0 이하이면 0', () => {
+		expect(computePercent(10, 0)).toBe(0)
+		expect(computePercent(10, -5)).toBe(0)
+	})
+
+	it('100을 넘지 않도록 클램프', () => {
+		expect(computePercent(120, 100)).toBe(100)
+	})
+})
+
+describe('evaluatePositionReport - heartbeat', () => {
+	it('10초가 지나지 않으면(9.9s) report 안 함', () => {
+		const result = evaluatePositionReport(state({ lastReportedAt: 0 }), {
+			currentTime: 1,
+			duration: 600,
+			now: 9_900
+		})
+		expect(result.shouldReport).toBe(false)
+		expect(result.lastReportedAt).toBe(0)
+		expect(result.fired90).toBe(false)
+	})
+
+	it('정확히 10초 경과 시 heartbeat report', () => {
+		const result = evaluatePositionReport(state({ lastReportedAt: 0 }), {
+			currentTime: 1,
+			duration: 600,
+			now: 10_000
+		})
+		expect(result.shouldReport).toBe(true)
+		expect(result.reason).toBe('heartbeat')
+		expect(result.lastReportedAt).toBe(10_000)
+	})
+})
+
+describe('evaluatePositionReport - 90% 강제발화', () => {
+	it('90% 지점을 처음 통과하면 throttle 무시하고 report', () => {
+		const result = evaluatePositionReport(state({ lastReportedAt: 9_500, fired90: false }), {
+			currentTime: 540,
+			duration: 600,
+			now: 9_600
+		})
+		expect(result.shouldReport).toBe(true)
+		expect(result.reason).toBe('threshold90')
+		expect(result.fired90).toBe(true)
+		expect(result.lastReportedAt).toBe(9_600)
+	})
+
+	it('이미 fired90 이면 90% 이상이어도 강제발화 안 함(1회성)', () => {
+		const result = evaluatePositionReport(state({ lastReportedAt: 9_500, fired90: true }), {
+			currentTime: 590,
+			duration: 600,
+			now: 9_600
+		})
+		expect(result.shouldReport).toBe(false)
+		expect(result.fired90).toBe(true)
+	})
+
+	it('짧은 영상(15s)도 heartbeat 없이 90%에서 강제발화', () => {
+		const result = evaluatePositionReport(state({ lastReportedAt: 0, fired90: false }), {
+			currentTime: 13.5,
+			duration: 15,
+			now: 2_000
+		})
+		expect(result.shouldReport).toBe(true)
+		expect(result.reason).toBe('threshold90')
+		expect(result.fired90).toBe(true)
+	})
+})
+
+describe('evaluatePositionReport - duration 가드', () => {
+	it('duration이 0이면 report 안 함', () => {
+		const result = evaluatePositionReport(state({ lastReportedAt: 0 }), {
+			currentTime: 5,
+			duration: 0,
+			now: 20_000
+		})
+		expect(result.shouldReport).toBe(false)
+		expect(result.fired90).toBe(false)
+	})
+})
+
+describe('createReportState', () => {
+	it('초기 상태는 lastReportedAt=0, fired90=false', () => {
+		expect(createReportState()).toEqual({ lastReportedAt: 0, fired90: false })
+	})
+})

--- a/frontend/tests/unit/features/session/progress-report.test.ts
+++ b/frontend/tests/unit/features/session/progress-report.test.ts
@@ -3,6 +3,7 @@ import {
 	evaluatePositionReport,
 	createReportState,
 	computePercent,
+	buildPositionBeacon,
 	type ReportState
 } from '$lib/features/session/progress-report'
 
@@ -96,6 +97,25 @@ describe('evaluatePositionReport - duration 가드', () => {
 		})
 		expect(result.shouldReport).toBe(false)
 		expect(result.fired90).toBe(false)
+	})
+})
+
+describe('buildPositionBeacon', () => {
+	it('PUT position URL과 JSON Blob payload를 만든다', () => {
+		const beacon = buildPositionBeacon('https://api.test', 700, 45.6, 90.2)
+		expect(beacon.url).toBe('https://api.test/progress/lesson/700/position')
+		expect(beacon.blob.type).toBe('application/json')
+	})
+
+	it('position/duration을 정수로 반올림한다', async () => {
+		const beacon = buildPositionBeacon('https://api.test', 700, 45.6, 90.2)
+		const body = JSON.parse(await beacon.blob.text())
+		expect(body).toEqual({ position_sec: 46, duration_sec: 90 })
+	})
+
+	it('baseUrl 끝 슬래시를 정규화한다', () => {
+		const beacon = buildPositionBeacon('https://api.test/', 700, 0, 0)
+		expect(beacon.url).toBe('https://api.test/progress/lesson/700/position')
 	})
 })
 

--- a/frontend/tests/unit/features/session/resume-position.test.ts
+++ b/frontend/tests/unit/features/session/resume-position.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('$lib/api/client/services.gen', () => ({
+	getLectureLectureLectureIdGet: vi.fn()
+}))
+
+const lectureDetail = (progress: unknown) => ({
+	data: {
+		id: 10,
+		title: 'L',
+		artist: null,
+		lessons: [],
+		description: '',
+		thumbnail: null,
+		tags: null,
+		length_sec: 0,
+		lecture_count: 0,
+		time_created: '',
+		time_updated: '',
+		progress
+	}
+})
+
+describe('fetchLessonResumePosition', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('lecture progress.lessons에서 lesson_id 매칭 last_position_sec를 반환', async () => {
+		const { getLectureLectureLectureIdGet } = await import('$lib/api/client/services.gen')
+		const { fetchLessonResumePosition } = await import('$lib/features/session/services')
+
+		vi.mocked(getLectureLectureLectureIdGet).mockResolvedValue(
+			lectureDetail({
+				completed_count: 0,
+				total_count: 1,
+				percent: 0,
+				next_lesson_id: 700,
+				completed_lesson_ids: [],
+				lessons: [{ lesson_id: 700, percent: 40, completed: false, last_position_sec: 72 }],
+				resume_lesson_id: 700,
+				resume_position_sec: 72
+			}) as any
+		)
+
+		const pos = await fetchLessonResumePosition(10, 700)
+		expect(getLectureLectureLectureIdGet).toHaveBeenCalledWith({ lectureId: 10 })
+		expect(pos).toBe(72)
+	})
+
+	it('매칭 레슨이 없으면 0', async () => {
+		const { getLectureLectureLectureIdGet } = await import('$lib/api/client/services.gen')
+		const { fetchLessonResumePosition } = await import('$lib/features/session/services')
+
+		vi.mocked(getLectureLectureLectureIdGet).mockResolvedValue(
+			lectureDetail({
+				completed_count: 0,
+				total_count: 1,
+				percent: 0,
+				next_lesson_id: 700,
+				completed_lesson_ids: [],
+				lessons: [],
+				resume_lesson_id: null,
+				resume_position_sec: 0
+			}) as any
+		)
+
+		expect(await fetchLessonResumePosition(10, 700)).toBe(0)
+	})
+
+	it('progress가 null이면 0', async () => {
+		const { getLectureLectureLectureIdGet } = await import('$lib/api/client/services.gen')
+		const { fetchLessonResumePosition } = await import('$lib/features/session/services')
+
+		vi.mocked(getLectureLectureLectureIdGet).mockResolvedValue(lectureDetail(null) as any)
+		expect(await fetchLessonResumePosition(10, 700)).toBe(0)
+	})
+
+	it('에러 시 0을 반환하고 throw하지 않는다', async () => {
+		const { getLectureLectureLectureIdGet } = await import('$lib/api/client/services.gen')
+		const { fetchLessonResumePosition } = await import('$lib/features/session/services')
+
+		vi.mocked(getLectureLectureLectureIdGet).mockRejectedValue(new Error('boom'))
+		expect(await fetchLessonResumePosition(10, 700)).toBe(0)
+	})
+})


### PR DESCRIPTION
## 개요
렉처 상세 진행도 패널이 실제 시청 데이터를 반영하도록, 세션 영상 시청 진행을 **수집·저장·노출**하는 파이프라인을 완성한다. Closes #133

기존엔 binary 완료 백엔드가 있었으나 **프론트가 진행을 전혀 리포팅하지 않아** 패널이 항상 0%였다. 이번에 부분 진행도(시청 위치)까지 확장하고 **누적 시청 ≥90%** 시 완료 처리한다.

## 주요 변경

### Backend
- `lesson_progress` 확장: `last_position_sec` / `duration_sec` / `progress_percent` 추가, `completed_at` nullable화 (Alembic `add_progress_position_001`, batch_alter로 SQLite/PG 호환)
- `ProgressRepository.upsert_position`(단조 percent·90% 완료 판정) + `get_progress_rows`
- `ProgressService` 집계 확장(per-lesson, resume 위치) + `report_position`
- `PUT /progress/lesson/{id}/position` 신규 엔드포인트
- `LectureProgressData` 확장: `lessons[]{lesson_id,percent,completed,last_position_sec}`, `resume_lesson_id`, `resume_position_sec`

### Frontend
- OpenAPI 클라이언트 재생성(`backend/openapi.json` 스냅샷 동기화)
- 위치 리포팅 순수함수 `progress-report.ts`: **10초 heartbeat + 90% 지점 1회 강제발화**(짧은 영상 자동 커버)
- 세션 페이지 배선: `ontimeupdate`/`onpause`/`onended`/`visibilitychange`/`beforeunload` → 리포팅. unload는 `fetch keepalive`(PUT)로 flush
- 진입 시 `last_position_sec`로 **이어보기 seek**
- 미니맵 **partial 셀** 상태 + per-lesson 진행도 + 서버 `resume_*` 우선. 헤드라인 링은 완료비율 유지

## 설계 결정
- 완료 트리거 = 누적 시청 ≥90%(협의). `progress_percent`는 단조 증가(되감기해도 감소 안 함)
- unload 전송: `PUT` 엔드포인트라 POST 전용 `navigator.sendBeacon` 대신 `fetch(keepalive)` 사용
- 이어보기 위치 출처: `GET /lecture`의 `progress.lessons[]`에서 lesson 매칭(세션 상세 응답엔 진행도 미포함)
- `$effect` 자기참조 무한루프(#125) 회귀 방지: 리포팅 판정을 순수함수+비반응 변수로 분리

## 검증
- Backend: `uv run pytest tests` **103 passed**, ruff 클린, 단일 alembic head
- Frontend: `vitest run` **215 passed**, `svelte-check` **0 errors**, 변경 파일 prettier 클린
- E2E(Playwright)는 로컬 flaky로 미실행 — 유닛+타입체크로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## QA 중 추가 변경 (세션 페이지)

진행도 기능 로컬 QA 과정에서 발견·요청된 변경을 동일 PR에 포함:

- 🐛 **세션 상세 강의 인덱스 1-based** — `lecture_ordering` 0-based 인데 헤더가 그대로 노출(`00/NN`) → `+1` 표시
- 🐛 **자막 롤러 휠 후 재생 추적 복귀** — 휠로 설정된 `manualIndex` 영구 고정으로 추적 멈추던 버그. 휠 멈춘 뒤 2s 후 해제
- ✨ **세션 → 강의 상세 돌아가기 UI** — 세션 제목 위 `← {강의 제목}` 링크(`/lecture/{lectureId}`)
- 🔥 **진행도 패널 막대 progress bar 제거** — 불필요 피드백 반영, 연쇄 dead code(buildMinimap/getLessonPercent 등) + 테스트 정리
- 🔥 **미사용 util 제거** — getLessonLastPosition/findLessonItem

검증: backend pytest 105 / frontend vitest 204 / svelte-check 0 errors / `make check-spec` PASS
