### PR TITLE
🐛 OAuth 로그인 직후 관리자 탭 미표시 버그 수정

### DIFF
--- a/frontend/src/routes/oauth-callback/+page.svelte
+++ b/frontend/src/routes/oauth-callback/+page.svelte
@@ -1,10 +1,19 @@
+<script module lang="ts">
+	import { setCurrentUser } from '$lib/features/auth'
+	import { usersCurrentUserUserMeGet } from '$lib/api'
+
+	export async function fetchAndStoreCurrentUser() {
+		const me = await usersCurrentUserUserMeGet()
+		setCurrentUser(me)
+		return me
+	}
+</script>
+
 <script lang="ts">
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
-	import { setIsAuthenticated } from '$lib/features/auth'
 	import {
 		oauthGoogleRedisCallbackUserOauthGoogleCallbackGet,
-		usersCurrentUserUserMeGet,
 		waitForApiInit
 	} from '$lib/api'
 	import { Spinner } from 'flowbite-svelte'
@@ -29,8 +38,7 @@
 			await oauthGoogleRedisCallbackUserOauthGoogleCallbackGet({ code, state })
 
 			if (typeof window !== 'undefined') {
-				await usersCurrentUserUserMeGet()
-				setIsAuthenticated(true)
+				await fetchAndStoreCurrentUser()
 
 				// sessionStorage에서 redirectUrl 읽기
 				let redirectUrl = sessionStorage.getItem('redirectUrl') || '/home'

--- a/frontend/tests/unit/features/auth/oauth-callback.test.ts
+++ b/frontend/tests/unit/features/auth/oauth-callback.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useAuth, setCurrentUser } from '$lib/features/auth'
+
+vi.mock('$lib/api', () => ({
+	usersCurrentUserUserMeGet: vi.fn()
+}))
+
+import { usersCurrentUserUserMeGet } from '$lib/api'
+
+describe('OAuth 콜백 사용자 동기화', () => {
+	beforeEach(() => {
+		setCurrentUser(null)
+		vi.clearAllMocks()
+	})
+
+	it('superuser 응답을 store에 반영하면 isAdmin과 isAuthenticated가 true', async () => {
+		vi.mocked(usersCurrentUserUserMeGet).mockResolvedValue({
+			nickname: 'admin',
+			email: 'admin@a.com',
+			is_artist: false,
+			is_superuser: true
+		} as never)
+
+		const { fetchAndStoreCurrentUser } = await import(
+			'../../../../src/routes/oauth-callback/+page.svelte'
+		)
+		await fetchAndStoreCurrentUser()
+
+		const auth = useAuth()
+		expect(auth.isAuthenticated).toBe(true)
+		expect(auth.isAdmin).toBe(true)
+	})
+
+	it('일반 사용자 응답이면 isAuthenticated는 true, isAdmin은 false', async () => {
+		vi.mocked(usersCurrentUserUserMeGet).mockResolvedValue({
+			nickname: 'user',
+			email: 'user@a.com',
+			is_artist: true,
+			is_superuser: false
+		} as never)
+
+		const { fetchAndStoreCurrentUser } = await import(
+			'../../../../src/routes/oauth-callback/+page.svelte'
+		)
+		await fetchAndStoreCurrentUser()
+
+		const auth = useAuth()
+		expect(auth.isAuthenticated).toBe(true)
+		expect(auth.isAdmin).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary
관리자(superuser)로 OAuth 로그인한 직후, **페이지를 새로고침하지 않으면** nav bar의 '관리자' 탭이 표시되지 않던 버그를 수정합니다. 새로고침하면 정상 표시되던 문제입니다.

### 근본 원인
- `oauth-callback/+page.svelte`가 콜백 성공 후 `usersCurrentUserUserMeGet()`의 **반환값을 버리고** `setIsAuthenticated(true)`만 호출 → auth store의 `currentUser`가 `null`로 남음.
- `isAdmin`은 `currentUser?.is_superuser === true`로 계산되므로 `currentUser`가 null이면 항상 false → 관리자 탭 미렌더링.
- 새로고침 시에는 `+layout.svelte`가 `setCurrentUser(me)`를 호출해 store를 채우므로 정상 동작. 이 호출이 OAuth 콜백 경로에만 빠져 있었음.

## Changes
- `frontend/src/routes/oauth-callback/+page.svelte`
  - 사용자 조회 + store 반영 로직을 `<script module>`의 `fetchAndStoreCurrentUser()`로 추출 (LoginModal과 동일한 테스트 가능 패턴).
  - 콜백 성공 시 `setIsAuthenticated(true)` 대신 `fetchAndStoreCurrentUser()` 호출 → `currentUser` 반영. (`setCurrentUser`가 `isAuthenticated`도 함께 갱신)
- `frontend/tests/unit/features/auth/oauth-callback.test.ts` (신규)
  - 콜백 동기화 로직이 superuser 응답을 store에 반영해 `isAdmin`/`isAuthenticated`가 true가 되는지 검증하는 회귀 테스트.
  - 일반 사용자는 `isAuthenticated=true`, `isAdmin=false` 검증.

> 참고: store의 `setCurrentUser`를 직접 호출하는 기존 유닛 테스트로는 "콜백이 setCurrentUser를 호출하지 않는" 이 버그를 잡을 수 없어, 콜백 경로 자체가 응답을 store에 반영하는지 검증하는 회귀 테스트를 추가했습니다.

## Test plan
- [x] `npx vitest run tests/unit/features/auth/` — 신규 2 + LoginModal 4 통과
- [x] `npx vitest run tests/unit/auth-store.test.ts` — 기존 3 통과 (회귀 없음)
- [x] `npx svelte-check` — 0 errors
- [ ] (수동) 관리자 계정으로 OAuth 로그인 직후, 새로고침 없이 nav bar에 '관리자' 탭이 보이는지 확인

---
🚀 Created via `/quick-pr`
🤖 Generated with [Claude Code](https://claude.com/claude-code)