### PR TITLE
🔧 staging sheetmusic 스토리지 시크릿 runbook 추가

### DIFF
--- a/infra/scripts/setup-staging-secrets.example.sh
+++ b/infra/scripts/setup-staging-secrets.example.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 #   flyctl releases -a sessionary-staging-backend
 #   flyctl deploy -a sessionary-staging-backend --image <previous-image>
 #
+# 참고: Sheetmusic 스토리지는 별도 비용을 피하기 위해 Video 와 동일한 Tigris
+#       버킷/자격증명을 공유한다 (SHEETMUSIC_STORAGE_* = VIDEO_STORAGE_* 값).
+#
 # =============================================================================
 
 echo "============================================"
@@ -57,7 +60,14 @@ flyctl secrets set -a sessionary-staging-backend \
   VIDEO_STORAGE_ACCESS_KEY="<tigris-access-key>" \
   VIDEO_STORAGE_SECRET_KEY="<tigris-secret-key>" \
   VIDEO_STORAGE_BUCKET_NAME="<tigris-bucket-name>" \
-  VIDEO_STORAGE_SECURE="true"
+  VIDEO_STORAGE_SECURE="true" \
+  SHEETMUSIC_PROVIDER="local" \
+  SHEETMUSIC_STORAGE_ENDPOINT="<tigris-endpoint>" \
+  SHEETMUSIC_STORAGE_PUBLIC_ENDPOINT="<tigris-endpoint>" \
+  SHEETMUSIC_STORAGE_ACCESS_KEY="<tigris-access-key>" \
+  SHEETMUSIC_STORAGE_SECRET_KEY="<tigris-secret-key>" \
+  SHEETMUSIC_STORAGE_BUCKET_NAME="<tigris-bucket-name>" \
+  SHEETMUSIC_STORAGE_SECURE="true"
 
 echo "[Backend] Done. Verifying..."
 flyctl secrets list -a sessionary-staging-backend


### PR DESCRIPTION
## 배경
staging 백엔드에 sheetmusic 스토리지가 구성돼 있지 않아(`SHEETMUSIC_STORAGE_*` 시크릿 부재) sheetmusic 서빙이 불가능했다. 이를 구성하며 runbook(example)을 최신화한다.

## 변경
- `setup-staging-secrets.example.sh` 의 backend 시크릿 블록에 `SHEETMUSIC_STORAGE_*` 추가.
- **별도 비용을 피하기 위해 Video 와 동일한 Tigris 버킷/자격증명을 공유**한다:
  - `SHEETMUSIC_PROVIDER=local`
  - `SHEETMUSIC_STORAGE_ENDPOINT`/`PUBLIC_ENDPOINT` = Tigris endpoint
  - `SHEETMUSIC_STORAGE_ACCESS_KEY`/`SECRET_KEY` = video 와 동일 Tigris 자격증명
  - `SHEETMUSIC_STORAGE_BUCKET_NAME` = video 버킷 재사용 (`sessionary-staging-video-storage`)
  - `SHEETMUSIC_STORAGE_SECURE=true`

## 적용 상태(실인프라)
- 위 시크릿은 이미 `flyctl secrets set -a sessionary-staging-backend` 로 적용·재배포 완료.
- 예시 musicxml(`examples/sample.musicxml`, `examples/sample-long.musicxml`)은 video 버킷에 업로드됨.
- 실제 `setup-staging-secrets.sh`(gitignore)도 동일하게 갱신됨.

## 비고
- staging DB `lesson.sheetmusic_url` 연결은 운영 DB 안전 가드로 보류 중(별도 승인 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)